### PR TITLE
[FEAT] Cahce 도입을 통한 성능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.env

--- a/backend/src/main/java/com/yachaerang/backend/api/product/controller/DailyPriceController.java
+++ b/backend/src/main/java/com/yachaerang/backend/api/product/controller/DailyPriceController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @RequestMapping("/api/v1/daily-prices")
@@ -31,7 +32,8 @@ public class DailyPriceController {
      */
     @GetMapping("/rank/high-prices")
     public List<DailyPriceResponseDto.RankDto> getHighPriceRank() {
-        return dailyPriceService.getHighPriceRank();
+        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+        return dailyPriceService.getHighPriceRank(yesterday);
     }
 
     /*
@@ -39,7 +41,8 @@ public class DailyPriceController {
      */
     @GetMapping("/rank/low-prices")
     public List<DailyPriceResponseDto.RankDto> getLowPriceRank() {
-        return dailyPriceService.getLowPriceRank();
+        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+        return dailyPriceService.getLowPriceRank(yesterday);
     }
 
 }

--- a/backend/src/main/java/com/yachaerang/backend/api/product/service/DailyPriceService.java
+++ b/backend/src/main/java/com/yachaerang/backend/api/product/service/DailyPriceService.java
@@ -3,12 +3,11 @@ package com.yachaerang.backend.api.product.service;
 import com.yachaerang.backend.api.product.dto.response.DailyPriceResponseDto;
 import com.yachaerang.backend.api.product.repository.DailyPriceMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 @Service
@@ -21,6 +20,11 @@ public class DailyPriceService {
     /*
     해당 기간 동안의 가격 전부 가져오기
      */
+    @Cacheable(
+            value = "daily:price",
+            key = "#productCode + ':' + #startDate + ':' + #endDate",
+            condition = "#endDate.isBefore(T(java.time.LocalDate).now())"
+    )
     public List<DailyPriceResponseDto.PriceRecordDto> getDailyPrice(
             String productCode, LocalDate startDate, LocalDate endDate) {
         return dailyPriceMapper.getPriceDuration(productCode, startDate, endDate);
@@ -28,19 +32,18 @@ public class DailyPriceService {
 
     /*
     어제자를 기준으로 가격이 높은 것부터 보여주기
+    날짜를 키로 사용하여 날짜가 바뀌면 자동으로 새 캐시 생성
      */
-    public List<DailyPriceResponseDto.RankDto> getHighPriceRank() {
-        ZonedDateTime today = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-        ZonedDateTime yesterday = today.minusDays(1);
-        return dailyPriceMapper.getPricesDescending(yesterday.toLocalDate());
+    @Cacheable(value = "daily:rank:high", key = "#date")
+    public List<DailyPriceResponseDto.RankDto> getHighPriceRank(LocalDate date) {
+        return dailyPriceMapper.getPricesDescending(date);
     }
 
     /*
     어제자를 기준으로 가격이 낮은 것부터 보여주기
      */
-    public List<DailyPriceResponseDto.RankDto> getLowPriceRank() {
-        ZonedDateTime today = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-        ZonedDateTime yesterday = today.minusDays(1);
-        return dailyPriceMapper.getPricesAscending(yesterday.toLocalDate());
+    @Cacheable(value = "daily:rank:low", key = "#date")
+    public List<DailyPriceResponseDto.RankDto> getLowPriceRank(LocalDate date) {
+        return dailyPriceMapper.getPricesAscending(date);
     }
 }

--- a/backend/src/main/java/com/yachaerang/backend/api/product/service/MonthlyPriceService.java
+++ b/backend/src/main/java/com/yachaerang/backend/api/product/service/MonthlyPriceService.java
@@ -3,6 +3,7 @@ package com.yachaerang.backend.api.product.service;
 import com.yachaerang.backend.api.product.dto.response.MonthlyPriceResponseDto;
 import com.yachaerang.backend.api.product.repository.MonthlyPriceMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,16 @@ public class MonthlyPriceService {
 
     private final MonthlyPriceMapper monthlyPriceMapper;
 
+    /*
+    종료 연월이 현재 월 이전인 경우만 캐시
+     */
+    @Cacheable(
+            value = "monthly:price",
+            key = "#productCode + ':' + #startYear + '-' + #startMonth + ':' + #endYear + '-' + #endMonth",
+            condition = "#endYear < T(java.time.LocalDate).now().getYear() or " +
+                        "(#endYear == T(java.time.LocalDate).now().getYear() and " +
+                        " #endMonth < T(java.time.LocalDate).now().getMonthValue())"
+    )
     public List<MonthlyPriceResponseDto.PriceDto> getMonthlyPrices(
             String productCode, int startYear, int startMonth,
             int endYear, int endMonth

--- a/backend/src/main/java/com/yachaerang/backend/api/product/service/ProductService.java
+++ b/backend/src/main/java/com/yachaerang/backend/api/product/service/ProductService.java
@@ -3,6 +3,7 @@ package com.yachaerang.backend.api.product.service;
 import com.yachaerang.backend.api.product.dto.response.ProductResponseDto;
 import com.yachaerang.backend.api.product.repository.ProductMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ public class ProductService {
     /*
     itemName에 대하여 반환
      */
+    @Cacheable(value = "product:itemNames")
     public List<ProductResponseDto.ItemDto> getItemNames() {
         return productMapper.findAllItemNameAndItemCodes();
     }
@@ -25,7 +27,8 @@ public class ProductService {
     /*
     상위의 itemCode 기반
      */
+    @Cacheable(value = "product:subItems", key = "#itemCode")
     public List<ProductResponseDto.SubItemDto> getProductNames(String itemCode) {
-        return  productMapper.findProductNameByItemCode(itemCode);
+        return productMapper.findProductNameByItemCode(itemCode);
     }
 }

--- a/backend/src/main/java/com/yachaerang/backend/api/product/service/WeeklyPriceService.java
+++ b/backend/src/main/java/com/yachaerang/backend/api/product/service/WeeklyPriceService.java
@@ -7,6 +7,7 @@ import com.yachaerang.backend.global.exception.GeneralException;
 import com.yachaerang.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,11 @@ public class WeeklyPriceService {
 
     private final WeeklyPriceMapper weeklyPriceMapper;
 
+    @Cacheable(
+            value = "weekly:price",
+            key = "#productCode + ':' + #startDate + ':' + #endDate",
+            condition = "#endDate.isBefore(T(java.time.LocalDate).now())"
+    )
     public List<WeeklyPriceResponseDto.PriceRecordDto> getPriceDuration(
             String productCode, LocalDate startDate, LocalDate endDate
     ) {

--- a/backend/src/main/java/com/yachaerang/backend/api/product/service/YearlyPriceService.java
+++ b/backend/src/main/java/com/yachaerang/backend/api/product/service/YearlyPriceService.java
@@ -3,6 +3,7 @@ package com.yachaerang.backend.api.product.service;
 import com.yachaerang.backend.api.product.dto.response.YearlyPriceResponseDto;
 import com.yachaerang.backend.api.product.repository.YearlyPriceMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,12 +16,28 @@ public class YearlyPriceService {
 
     private final YearlyPriceMapper yearlyPriceMapper;
 
+    /*
+    종료 연도가 올해 이전인 경우만 캐시
+     */
+    @Cacheable(
+            value = "yearly:price",
+            key = "#productCode + ':' + #startYear + ':' + #endYear",
+            condition = "#endYear < T(java.time.LocalDate).now().getYear()"
+    )
     public List<YearlyPriceResponseDto.PriceDto> getPrices(
             String productCode, int startYear, int endYear
     ) {
         return yearlyPriceMapper.getPriceDuration(productCode, startYear, endYear);
     }
 
+    /*
+    대상 연도가 올해 이전인 경우만 캐시
+     */
+    @Cacheable(
+            value = "yearly:price",
+            key = "#productCode + ':' + #targetYear",
+            condition = "#targetYear < T(java.time.LocalDate).now().getYear()"
+    )
     public YearlyPriceResponseDto.PriceDto getPrice(
             String productCode, int targetYear
     ) {

--- a/backend/src/main/java/com/yachaerang/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/yachaerang/backend/global/config/RedisConfig.java
@@ -1,17 +1,28 @@
 package com.yachaerang.backend.global.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 
+import java.time.Duration;
+import java.util.Map;
+
+@EnableCaching
 @RequiredArgsConstructor
 @Configuration
 public class RedisConfig {
@@ -33,12 +44,48 @@ public class RedisConfig {
 
     // Redis Lettuce 기반 연결
     @Bean
-    public RedisConnectionFactory redisConnectionFactory(){
-
+    public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(redisHost);
         config.setPort(redisPort);
         config.setPassword(redisPassword);
         return new LettuceConnectionFactory(config);
+    }
+
+    // Cache 전용
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+        ObjectMapper cacheMapper = new ObjectMapper();
+        cacheMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        cacheMapper.registerModule(new JavaTimeModule());
+        cacheMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(cacheMapper);
+
+        RedisCacheConfiguration defaults = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> cacheConfigs = Map.of(
+                "product:itemNames",  defaults.entryTtl(Duration.ofHours(24)),
+                "product:subItems",   defaults.entryTtl(Duration.ofHours(24)),
+                "daily:rank:high",    defaults.entryTtl(Duration.ofHours(24)),
+                "daily:rank:low",     defaults.entryTtl(Duration.ofHours(24)),
+                "daily:price",        defaults.entryTtl(Duration.ofDays(7)),
+                "weekly:price",       defaults.entryTtl(Duration.ofDays(7)),
+                "monthly:price",      defaults.entryTtl(Duration.ofDays(30)),
+                "yearly:price",       defaults.entryTtl(Duration.ofDays(365))
+        );
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(defaults)
+                .withInitialCacheConfigurations(cacheConfigs)
+                .build();
     }
 }

--- a/backend/src/main/java/com/yachaerang/backend/infrastructure/batch/client/WebClientBatchHttpTemplate.java
+++ b/backend/src/main/java/com/yachaerang/backend/infrastructure/batch/client/WebClientBatchHttpTemplate.java
@@ -20,7 +20,7 @@ public class WebClientBatchHttpTemplate implements BatchHttpTemplate {
 
     private final WebClient batchWebClient;
 
-    private static final Duration TIMEOUT = Duration.ofMillis(10000);
+    private static final Duration TIMEOUT = Duration.ofMillis(60000);
 
     @Override
     public <T> T get(String path, Class<T> type, UnaryOperator<UriBuilder> params) {

--- a/backend/src/test/java/com/yachaerang/backend/api/farm/controller/FarmControllerTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/farm/controller/FarmControllerTest.java
@@ -3,6 +3,8 @@ package com.yachaerang.backend.api.farm.controller;
 import com.yachaerang.backend.api.farm.dto.response.FarmResponseDto;
 import com.yachaerang.backend.api.farm.dto.resquest.FarmRequestDto;
 import com.yachaerang.backend.api.farm.service.FarmService;
+import com.yachaerang.backend.global.exception.GeneralException;
+import com.yachaerang.backend.global.response.ErrorCode;
 import com.yachaerang.backend.global.util.RestDocsSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -229,5 +231,89 @@ class FarmControllerTest extends RestDocsSupport {
                 ));
 
         verify(farmService).updateFarmInfo(any(FarmRequestDto.InfoDto.class));
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/farms - GeneralException 시 해당 에러코드로 응답")
+    void saveFarm_GeneralException() throws Exception {
+        // given
+        FarmRequestDto.InfoDto requestDto = createRequestDto();
+        given(farmService.saveFarmInfo(any(FarmRequestDto.InfoDto.class)))
+                .willReturn(CompletableFuture.failedFuture(
+                        new GeneralException(ErrorCode.FARM_ALREADY_EXISTS)));
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(post("/api/v1/farms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTH_HEADER, TEST_TOKEN)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/farms - RuntimeException 시 500 응답")
+    void saveFarm_RuntimeException() throws Exception {
+        // given
+        FarmRequestDto.InfoDto requestDto = createRequestDto();
+        given(farmService.saveFarmInfo(any(FarmRequestDto.InfoDto.class)))
+                .willReturn(CompletableFuture.failedFuture(
+                        new RuntimeException("unexpected error")));
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(post("/api/v1/farms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTH_HEADER, TEST_TOKEN)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("[PATCH] /api/v1/farms - GeneralException 시 해당 에러코드로 응답")
+    void updateFarm_GeneralException() throws Exception {
+        // given
+        FarmRequestDto.InfoDto requestDto = createRequestDto();
+        given(farmService.updateFarmInfo(any(FarmRequestDto.InfoDto.class)))
+                .willReturn(CompletableFuture.failedFuture(
+                        new GeneralException(ErrorCode.FARM_NOT_FOUND)));
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(patch("/api/v1/farms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTH_HEADER, TEST_TOKEN)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("[PATCH] /api/v1/farms - RuntimeException 시 500 응답")
+    void updateFarm_RuntimeException() throws Exception {
+        // given
+        FarmRequestDto.InfoDto requestDto = createRequestDto();
+        given(farmService.updateFarmInfo(any(FarmRequestDto.InfoDto.class)))
+                .willReturn(CompletableFuture.failedFuture(
+                        new RuntimeException("unexpected error")));
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(patch("/api/v1/farms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTH_HEADER, TEST_TOKEN)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isInternalServerError());
     }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/farm/service/FarmServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/farm/service/FarmServiceTest.java
@@ -208,4 +208,55 @@ class FarmServiceTest {
                     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FARM_NOT_FOUND);
                 });
     }
+
+    @Test
+    @DisplayName("농장 정보 저장 실패 - 이미 존재하는 농장")
+    void 농장정보_저장_실패_이미존재하는_농장() {
+        // given
+        FarmRequestDto.InfoDto requestDto = createRequestDto();
+        FarmResponseDto.EvaluateDto evaluationDto = new FarmResponseDto.EvaluateDto("A", "좋은 유형", "좋은 농장입니다");
+        Farm existingFarm = createFarm();
+
+        when(farmEvaluationService.generateGradeAndComment(requestDto))
+                .thenReturn(CompletableFuture.completedFuture(evaluationDto));
+        when(farmMapper.findByMemberId(MEMBER_ID)).thenReturn(existingFarm);
+
+        // when
+        CompletableFuture<FarmResponseDto.InfoDto> result = farmService.saveFarmInfo(requestDto);
+
+        // then
+        assertThatThrownBy(result::join)
+                .isInstanceOf(CompletionException.class)
+                .cause()
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> {
+                    GeneralException exception = (GeneralException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FARM_ALREADY_EXISTS);
+                });
+    }
+
+    @Test
+    @DisplayName("농장 정보 수정 실패 - AI 평가 실패")
+    void 농장정보_수정_실패_AI평가_실패() {
+        // given
+        FarmRequestDto.InfoDto requestDto = createRequestDto();
+        Farm existingFarm = createFarm();
+
+        when(farmMapper.findByMemberId(MEMBER_ID)).thenReturn(existingFarm);
+        when(farmEvaluationService.generateGradeAndComment(requestDto))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("AI 서비스 오류")));
+
+        // when
+        CompletableFuture<FarmResponseDto.InfoDto> result = farmService.updateFarmInfo(requestDto);
+
+        // then
+        assertThatThrownBy(result::join)
+                .isInstanceOf(CompletionException.class)
+                .cause()
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> {
+                    GeneralException exception = (GeneralException) e;
+                    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FARM_UPDATE_FAILED);
+                });
+    }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/member/service/MemberServiceTest.java
@@ -362,4 +362,159 @@ class MemberServiceTest {
 
         then(s3FileService).should().upload(eq(file), argThat(filename -> !filename.contains(".")));
     }
+
+    @Test
+    @DisplayName("프로필 사진 업로드 실패 - 파일이 null")
+    void 프로필_사진_업로드_실패_파일null() {
+        // given
+        given(authenticatedMemberProvider.getCurrentMemberId()).willReturn(1L);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.uploadProfileImage(null))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> assertThat(((GeneralException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MEMBER_PROFILE_IMAGE));
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업로드 실패 - 빈 파일")
+    void 프로필_사진_업로드_실패_빈파일() {
+        // given
+        MultipartFile file = mock(MultipartFile.class);
+        given(file.isEmpty()).willReturn(true);
+        given(authenticatedMemberProvider.getCurrentMemberId()).willReturn(1L);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.uploadProfileImage(file))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> assertThat(((GeneralException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MEMBER_PROFILE_IMAGE));
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업로드 실패 - 파일 크기 초과")
+    void 프로필_사진_업로드_실패_파일크기초과() {
+        // given
+        MultipartFile file = mock(MultipartFile.class);
+        given(file.isEmpty()).willReturn(false);
+        given(file.getSize()).willReturn(2 * 1024 * 1024L);
+        given(authenticatedMemberProvider.getCurrentMemberId()).willReturn(1L);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.uploadProfileImage(file))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> assertThat(((GeneralException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.PROFILE_IMAGE_TOO_MUCH));
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업로드 실패 - DB 업데이트 실패")
+    void 프로필_사진_업로드_실패_DB업데이트실패() {
+        // given
+        Long memberId = 1L;
+        MultipartFile file = mock(MultipartFile.class);
+        given(file.isEmpty()).willReturn(false);
+        given(file.getSize()).willReturn(500 * 1024L);
+        given(file.getOriginalFilename()).willReturn("test.png");
+
+        given(authenticatedMemberProvider.getCurrentMemberId()).willReturn(memberId);
+        given(memberMapper.findImageUrl(memberId)).willReturn(null);
+        given(s3FileService.upload(eq(file), anyString())).willReturn("https://s3.new/image.png");
+        given(memberMapper.updateProfileImage(anyString(), eq(memberId))).willReturn(0);
+
+        TransactionSynchronizationManager.initSynchronization();
+
+        // when & then
+        assertThatThrownBy(() -> memberService.uploadProfileImage(file))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> assertThat(((GeneralException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MEMBER_PROFILE_IMAGE));
+
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업로드 성공 - 기존 이미지 URL이 빈 문자열이면 S3 삭제 안 함")
+    void 프로필_사진_업로드_성공_기존이미지URL빈문자열() {
+        // given
+        Long memberId = 1L;
+        MultipartFile file = mock(MultipartFile.class);
+        given(file.getOriginalFilename()).willReturn("test.png");
+
+        given(authenticatedMemberProvider.getCurrentMemberId()).willReturn(memberId);
+        given(memberMapper.findImageUrl(memberId)).willReturn("");
+        given(s3FileService.upload(eq(file), anyString())).willReturn("https://s3.new/image.png");
+        given(memberMapper.updateProfileImage("https://s3.new/image.png", memberId)).willReturn(1);
+
+        TransactionSynchronizationManager.initSynchronization();
+
+        // when
+        memberService.uploadProfileImage(file);
+
+        // then
+        List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
+        syncs.forEach(TransactionSynchronization::afterCommit);
+
+        verify(s3FileService, never()).deleteByUrl(anyString());
+
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 기존 비밀번호 불일치")
+    void 비밀번호_변경_실패_기존비밀번호불일치() {
+        // given
+        String oldPassword = "WrongPassword";
+        String encodedOldPassword = "$2a$10$encodedOldPassword";
+
+        MemberRequestDto.PasswordDto requestDto = MemberRequestDto.PasswordDto.builder()
+                .oldPassword(oldPassword)
+                .newPassword("NewPassword123")
+                .build();
+
+        Member testMember = Member.builder()
+                .email("test@example.com")
+                .password(encodedOldPassword)
+                .build();
+
+        given(authenticatedMemberProvider.getMemberByContextHolder()).willReturn(testMember);
+        given(bCryptPasswordEncoder.matches(oldPassword, encodedOldPassword)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.changePassword(requestDto))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> assertThat(((GeneralException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.UNMATCHED_PASSWORD));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - DB 업데이트 실패")
+    void 비밀번호_변경_실패_DB업데이트실패() {
+        // given
+        String oldPassword = "OldPassword123";
+        String newPassword = "NewPassword123";
+        String encodedOldPassword = "$2a$10$encodedOldPassword";
+        String encodedNewPassword = "$2a$10$encodedNewPassword";
+
+        MemberRequestDto.PasswordDto requestDto = MemberRequestDto.PasswordDto.builder()
+                .oldPassword(oldPassword)
+                .newPassword(newPassword)
+                .build();
+
+        Member testMember = Member.builder()
+                .email("test@example.com")
+                .password(encodedOldPassword)
+                .build();
+
+        given(authenticatedMemberProvider.getMemberByContextHolder()).willReturn(testMember);
+        given(bCryptPasswordEncoder.matches(oldPassword, encodedOldPassword)).willReturn(true);
+        given(bCryptPasswordEncoder.encode(newPassword)).willReturn(encodedNewPassword);
+        given(memberMapper.updatePassword(testMember.getEmail(), encodedNewPassword)).willReturn(0);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.changePassword(requestDto))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(e -> assertThat(((GeneralException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MEMBER_PASSWORD_FAILED));
+    }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/product/controller/DailyPriceControllerTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/controller/DailyPriceControllerTest.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -198,7 +199,7 @@ class DailyPriceControllerTest extends RestDocsSupport {
     @DisplayName("[GET] /api/v1/daily-prices/rank/high-prices")
     public void getHighPrices() throws Exception {
         // given
-        given(dailyPriceService.getHighPriceRank())
+        given(dailyPriceService.getHighPriceRank(any(LocalDate.class)))
                 .willReturn(rankList1);
         // when & then
         mockMvc.perform(get("/api/v1/daily-prices/rank/high-prices")
@@ -227,7 +228,7 @@ class DailyPriceControllerTest extends RestDocsSupport {
     @DisplayName("[GET] /api/v1/daily-prices/rank/low-prices")
     public void getLowPrices() throws Exception {
         // given
-        given(dailyPriceService.getLowPriceRank())
+        given(dailyPriceService.getLowPriceRank(any(LocalDate.class)))
                 .willReturn(rankList2);
         // when & then
         mockMvc.perform(get("/api/v1/daily-prices/rank/low-prices")

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/DailyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/DailyPriceServiceTest.java
@@ -2,22 +2,28 @@ package com.yachaerang.backend.api.product.service;
 
 import com.yachaerang.backend.api.product.dto.response.DailyPriceResponseDto;
 import com.yachaerang.backend.api.product.repository.DailyPriceMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.List;
-
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -33,10 +39,7 @@ class DailyPriceServiceTest {
     @InjectMocks
     DailyPriceService dailyPriceService;
 
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
-    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.of(
-            2024, 1, 15, 10, 0, 0, 0, SEOUL_ZONE
-    );
+    // 리팩터링 후 날짜 계산은 컨트롤러에서 수행하며, 서비스는 date 파라미터를 받음
     private static final LocalDate YESTERDAY = LocalDate.of(2024, 1, 14);
 
     private List<DailyPriceResponseDto.RankDto> createDescendingMockData() {
@@ -192,64 +195,180 @@ class DailyPriceServiceTest {
     @Test
     @DisplayName("어제 날짜를 기준으로 가격 내림차순")
     void 어제날짜를_기준으로_가격_내림차순() {
-        try (MockedStatic<ZonedDateTime> mockedZonedDateTime = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-            // given
-            // any(ZoneId.class)를 사용하여 ZoneId 매칭 문제 해결
-            mockedZonedDateTime.when(() -> ZonedDateTime.now(any(ZoneId.class)))
-                    .thenReturn(FIXED_NOW);
+        // given - 날짜 계산은 컨트롤러에서 수행 후 파라미터로 전달
+        given(dailyPriceMapper.getPricesDescending(YESTERDAY))
+                .willReturn(createDescendingMockData());
 
-            given(dailyPriceMapper.getPricesDescending(YESTERDAY))
-                    .willReturn(createDescendingMockData());
+        // when
+        List<DailyPriceResponseDto.RankDto> result = dailyPriceService.getHighPriceRank(YESTERDAY);
 
-            // when
-            List<DailyPriceResponseDto.RankDto> result = dailyPriceService.getHighPriceRank();
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getProductName()).isEqualTo("수박");
+        assertThat(result.get(0).getPrice()).isEqualTo(20000);
 
-            // then
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).getProductName()).isEqualTo("수박");
-            assertThat(result.get(0).getPrice()).isEqualTo(20000);
-
-            verify(dailyPriceMapper).getPricesDescending(YESTERDAY);
-        }
+        verify(dailyPriceMapper).getPricesDescending(YESTERDAY);
     }
 
     @Test
     @DisplayName("데이터가 없으면 빈 리스트")
     void 데이터가_없으면_빈리스트() {
-        try (MockedStatic<ZonedDateTime> mockedZonedDateTime = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-            // given
-            mockedZonedDateTime.when(() -> ZonedDateTime.now(SEOUL_ZONE)).thenReturn(FIXED_NOW);
+        // given
+        given(dailyPriceMapper.getPricesDescending(YESTERDAY))
+                .willReturn(Collections.emptyList());
 
-            given(dailyPriceMapper.getPricesDescending(YESTERDAY))
-                    .willReturn(Collections.emptyList());
+        // when
+        List<DailyPriceResponseDto.RankDto> result = dailyPriceService.getHighPriceRank(YESTERDAY);
 
-            // when
-            List<DailyPriceResponseDto.RankDto> result = dailyPriceService.getHighPriceRank();
-
-            // then
-            assertThat(result).isEmpty();
-        }
+        // then
+        assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("어제 날짜를 기준으로 가격 오름차순")
     void 어제날짜를_기준으로_가격_오름차순() {
-        try (MockedStatic<ZonedDateTime> mockedZonedDateTime = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-            // given
-            mockedZonedDateTime.when(() -> ZonedDateTime.now(SEOUL_ZONE)).thenReturn(FIXED_NOW);
+        // given
+        given(dailyPriceMapper.getPricesAscending(YESTERDAY))
+                .willReturn(createAscendingMockData());
 
-            given(dailyPriceMapper.getPricesAscending(YESTERDAY))
-                    .willReturn(createAscendingMockData());
+        // when
+        List<DailyPriceResponseDto.RankDto> result = dailyPriceService.getLowPriceRank(YESTERDAY);
 
-            // when
-            List<DailyPriceResponseDto.RankDto> result = dailyPriceService.getLowPriceRank();
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getProductName()).isEqualTo("감귤");
+        assertThat(result.get(0).getPrice()).isEqualTo(2000L);
 
-            // then
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).getProductName()).isEqualTo("감귤");
-            assertThat(result.get(0).getPrice()).isEqualTo(2000L);
+        verify(dailyPriceMapper).getPricesAscending(YESTERDAY);
+    }
 
-            verify(dailyPriceMapper).getPricesAscending(YESTERDAY);
+    // ─── 캐시 레이어 테스트 ────────────────────────────────────────────────────
+    // @Cacheable AOP는 Spring 프록시가 있어야 동작하므로 SpringExtension + ConcurrentMapCache 사용
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = CacheLayerTest.TestConfig.class)
+    class CacheLayerTest {
+
+        @Configuration
+        @EnableCaching
+        static class TestConfig {
+
+            @Bean
+            public CacheManager cacheManager() {
+                return new ConcurrentMapCacheManager(
+                        "daily:price", "daily:rank:high", "daily:rank:low");
+            }
+
+            @Bean
+            public DailyPriceMapper dailyPriceMapper() {
+                return Mockito.mock(DailyPriceMapper.class);
+            }
+
+            @Bean
+            public DailyPriceService dailyPriceService(DailyPriceMapper dailyPriceMapper) {
+                return new DailyPriceService(dailyPriceMapper);
+            }
+        }
+
+        @Autowired
+        DailyPriceMapper dailyPriceMapper;
+
+        @Autowired
+        DailyPriceService dailyPriceService;
+
+        @Autowired
+        CacheManager cacheManager;
+
+        @BeforeEach
+        void resetMocksAndCaches() {
+            Mockito.reset(dailyPriceMapper);
+            cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+        }
+
+        @Test
+        @DisplayName("과거 기간 조회: 두 번째 호출은 캐시에서 반환 (매퍼 1회 호출)")
+        void 과거기간_두번째호출_캐시히트() {
+            String productCode = "PROD001";
+            LocalDate startDate = LocalDate.of(2024, 1, 1);
+            LocalDate endDate = LocalDate.of(2024, 1, 31); // 과거 → condition = true → 캐시 적용
+
+            List<DailyPriceResponseDto.PriceRecordDto> data = List.of(
+                    DailyPriceResponseDto.PriceRecordDto.builder()
+                            .priceDate(startDate).price(10000L).build()
+            );
+            given(dailyPriceMapper.getPriceDuration(productCode, startDate, endDate)).willReturn(data);
+
+            dailyPriceService.getDailyPrice(productCode, startDate, endDate); // 캐시 미스 → 매퍼 호출
+            dailyPriceService.getDailyPrice(productCode, startDate, endDate); // 캐시 히트 → 매퍼 미호출
+
+            verify(dailyPriceMapper, times(1)).getPriceDuration(productCode, startDate, endDate);
+        }
+
+        @Test
+        @DisplayName("오늘 날짜가 endDate인 기간: 캐시 조건 미충족으로 매퍼 매번 호출")
+        void 오늘이_endDate인_기간_캐시조건_미충족() {
+            String productCode = "PROD001";
+            LocalDate startDate = LocalDate.of(2024, 1, 1);
+            LocalDate endDate = LocalDate.now(); // 오늘 → endDate.isBefore(now) = false → 캐시 미적용
+
+            given(dailyPriceMapper.getPriceDuration(productCode, startDate, endDate))
+                    .willReturn(Collections.emptyList());
+
+            dailyPriceService.getDailyPrice(productCode, startDate, endDate);
+            dailyPriceService.getDailyPrice(productCode, startDate, endDate);
+
+            verify(dailyPriceMapper, times(2)).getPriceDuration(productCode, startDate, endDate);
+        }
+
+        @Test
+        @DisplayName("랭크 조회: 동일 날짜 두 번 호출 시 캐시 히트 (매퍼 1회 호출)")
+        void 랭크조회_동일날짜_캐시히트() {
+            LocalDate date = LocalDate.of(2024, 1, 14);
+            List<DailyPriceResponseDto.RankDto> data = List.of(
+                    DailyPriceResponseDto.RankDto.builder()
+                            .productCode("APPLE").productName("사과")
+                            .itemName("과일").kindName("사과")
+                            .unit("kg").price(5000L).build()
+            );
+            given(dailyPriceMapper.getPricesDescending(date)).willReturn(data);
+
+            dailyPriceService.getHighPriceRank(date);
+            dailyPriceService.getHighPriceRank(date);
+
+            verify(dailyPriceMapper, times(1)).getPricesDescending(date);
+        }
+
+        @Test
+        @DisplayName("랭크 조회: 다른 날짜는 별도 캐시 키 → 각각 매퍼 호출")
+        void 랭크조회_다른날짜_별도캐시키() {
+            LocalDate date1 = LocalDate.of(2024, 1, 13);
+            LocalDate date2 = LocalDate.of(2024, 1, 14);
+
+            given(dailyPriceMapper.getPricesDescending(date1)).willReturn(Collections.emptyList());
+            given(dailyPriceMapper.getPricesDescending(date2)).willReturn(Collections.emptyList());
+
+            dailyPriceService.getHighPriceRank(date1);
+            dailyPriceService.getHighPriceRank(date2);
+
+            verify(dailyPriceMapper, times(1)).getPricesDescending(date1);
+            verify(dailyPriceMapper, times(1)).getPricesDescending(date2);
+        }
+
+        @Test
+        @DisplayName("내림차순·오름차순 랭크는 별도 캐시('daily:rank:high', 'daily:rank:low') 사용")
+        void 고가랭크_저가랭크_별도캐시() {
+            LocalDate date = LocalDate.of(2024, 1, 14);
+
+            given(dailyPriceMapper.getPricesDescending(date)).willReturn(Collections.emptyList());
+            given(dailyPriceMapper.getPricesAscending(date)).willReturn(Collections.emptyList());
+
+            dailyPriceService.getHighPriceRank(date);
+            dailyPriceService.getHighPriceRank(date); // 캐시 히트
+            dailyPriceService.getLowPriceRank(date);
+            dailyPriceService.getLowPriceRank(date);  // 캐시 히트
+
+            verify(dailyPriceMapper, times(1)).getPricesDescending(date);
+            verify(dailyPriceMapper, times(1)).getPricesAscending(date);
         }
     }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/DailyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/DailyPriceServiceTest.java
@@ -19,8 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@Transactional
 @ExtendWith(MockitoExtension.class)
 class DailyPriceServiceTest {
 

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/MonthlyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/MonthlyPriceServiceTest.java
@@ -19,8 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +28,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@Transactional
 @ExtendWith(MockitoExtension.class)
 class MonthlyPriceServiceTest {
 

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/MonthlyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/MonthlyPriceServiceTest.java
@@ -2,14 +2,26 @@ package com.yachaerang.backend.api.product.service;
 
 import com.yachaerang.backend.api.product.dto.response.MonthlyPriceResponseDto;
 import com.yachaerang.backend.api.product.repository.MonthlyPriceMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,7 +41,7 @@ class MonthlyPriceServiceTest {
     @DisplayName("월별 가격 데이터 반환 성공")
     void 월별가격데이터를_반환_성공() {
         // given
-        String productCoe = "PRODUCT01";
+        String productCode = "PRODUCT01";
         int startYear = 2024;
         int startMonth = 1;
         int endYear = 2024;
@@ -57,43 +69,43 @@ class MonthlyPriceServiceTest {
                         .minPrice(8000L)
                         .maxPrice(10000L)
                         .build()
-                );
-        given(monthlyPriceMapper.getPriceDuration(productCoe, startYear, startMonth, endYear, endMonth))
+        );
+        given(monthlyPriceMapper.getPriceDuration(productCode, startYear, startMonth, endYear, endMonth))
                 .willReturn(expectedResult);
 
         // when
         List<MonthlyPriceResponseDto.PriceDto> result = monthlyPriceService.getMonthlyPrices(
-                productCoe, startYear, startMonth, endYear, endMonth
+                productCode, startYear, startMonth, endYear, endMonth
         );
 
         // then
         assertThat(result).hasSize(expectedResult.size());
         assertThat(result).isEqualTo(expectedResult);
         verify(monthlyPriceMapper, times(1))
-                .getPriceDuration(productCoe, startYear, startMonth, endYear, endMonth);
+                .getPriceDuration(productCode, startYear, startMonth, endYear, endMonth);
     }
 
     @Test
     @DisplayName("데이터가 없으면 빈 리스트")
     void 데이터가_없으면_빈리스트(){
         // given
-        String productCoe = "PRODUCT01";
+        String productCode = "PRODUCT01";
         int startYear = 2024;
         int startMonth = 1;
         int endYear = 2024;
         int endMonth = 6;
-        given(monthlyPriceMapper.getPriceDuration(productCoe, startYear, startMonth, endYear, endMonth))
+        given(monthlyPriceMapper.getPriceDuration(productCode, startYear, startMonth, endYear, endMonth))
                 .willReturn(Collections.emptyList());
 
         // when
         List<MonthlyPriceResponseDto.PriceDto> result = monthlyPriceService.getMonthlyPrices(
-                productCoe, startYear, startMonth, endYear, endMonth
+                productCode, startYear, startMonth, endYear, endMonth
         );
 
         // then
         assertThat(result).hasSize(0);
         verify(monthlyPriceMapper, times(1))
-                .getPriceDuration(productCoe, startYear, startMonth, endYear, endMonth);
+                .getPriceDuration(productCode, startYear, startMonth, endYear, endMonth);
     }
 
     @Test
@@ -126,5 +138,121 @@ class MonthlyPriceServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getPriceYear()).isEqualTo(2024);
         assertThat(result.get(0).getPriceMonth()).isEqualTo(5);
+    }
+
+    // ─── 캐시 레이어 테스트 ────────────────────────────────────────────────────
+    // 캐시 조건: endYear < now().year  OR  (endYear == now().year AND endMonth < now().month)
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = CacheLayerTest.TestConfig.class)
+    class CacheLayerTest {
+
+        @Configuration
+        @EnableCaching
+        static class TestConfig {
+
+            @Bean
+            public CacheManager cacheManager() {
+                return new ConcurrentMapCacheManager("monthly:price");
+            }
+
+            @Bean
+            public MonthlyPriceMapper monthlyPriceMapper() {
+                return Mockito.mock(MonthlyPriceMapper.class);
+            }
+
+            @Bean
+            public MonthlyPriceService monthlyPriceService(MonthlyPriceMapper monthlyPriceMapper) {
+                return new MonthlyPriceService(monthlyPriceMapper);
+            }
+        }
+
+        @Autowired
+        MonthlyPriceMapper monthlyPriceMapper;
+
+        @Autowired
+        MonthlyPriceService monthlyPriceService;
+
+        @Autowired
+        CacheManager cacheManager;
+
+        @BeforeEach
+        void resetMocksAndCaches() {
+            Mockito.reset(monthlyPriceMapper);
+            cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+        }
+
+        @Test
+        @DisplayName("과거 연도 기간 조회: 두 번째 호출은 캐시에서 반환 (매퍼 1회 호출)")
+        void 과거연도기간_두번째호출_캐시히트() {
+            String productCode = "PROD001";
+            // endYear(2024) < currentYear(2026) → 조건 충족 → 캐시 적용
+            int startYear = 2024, startMonth = 1, endYear = 2024, endMonth = 6;
+
+            given(monthlyPriceMapper.getPriceDuration(productCode, startYear, startMonth, endYear, endMonth))
+                    .willReturn(Collections.emptyList());
+
+            monthlyPriceService.getMonthlyPrices(productCode, startYear, startMonth, endYear, endMonth);
+            monthlyPriceService.getMonthlyPrices(productCode, startYear, startMonth, endYear, endMonth);
+
+            verify(monthlyPriceMapper, times(1))
+                    .getPriceDuration(productCode, startYear, startMonth, endYear, endMonth);
+        }
+
+        @Test
+        @DisplayName("현재 연월 기간 조회: 캐시 조건 미충족으로 매퍼 매번 호출")
+        void 현재연월_기간_캐시조건_미충족() {
+            String productCode = "PROD001";
+            int currentYear = LocalDate.now().getYear();
+            int currentMonth = LocalDate.now().getMonthValue();
+            // endYear == currentYear AND endMonth == currentMonth → 조건 미충족 → 캐시 미적용
+            int startYear = currentYear, startMonth = 1;
+
+            given(monthlyPriceMapper.getPriceDuration(productCode, startYear, startMonth, currentYear, currentMonth))
+                    .willReturn(Collections.emptyList());
+
+            monthlyPriceService.getMonthlyPrices(productCode, startYear, startMonth, currentYear, currentMonth);
+            monthlyPriceService.getMonthlyPrices(productCode, startYear, startMonth, currentYear, currentMonth);
+
+            verify(monthlyPriceMapper, times(2))
+                    .getPriceDuration(productCode, startYear, startMonth, currentYear, currentMonth);
+        }
+
+        @Test
+        @DisplayName("같은 연도 이전 월 기간 조회: 캐시 조건 충족")
+        void 같은연도_이전월_기간_캐시조건_충족() {
+            String productCode = "PROD001";
+            int currentYear = LocalDate.now().getYear();
+            int previousMonth = LocalDate.now().minusMonths(2).getMonthValue();
+            int previousMonthYear = LocalDate.now().minusMonths(2).getYear();
+
+            // endYear == currentYear AND endMonth < currentMonth → 조건 충족 → 캐시 적용
+            given(monthlyPriceMapper.getPriceDuration(productCode, previousMonthYear, 1, previousMonthYear, previousMonth))
+                    .willReturn(Collections.emptyList());
+
+            monthlyPriceService.getMonthlyPrices(productCode, previousMonthYear, 1, previousMonthYear, previousMonth);
+            monthlyPriceService.getMonthlyPrices(productCode, previousMonthYear, 1, previousMonthYear, previousMonth);
+
+            verify(monthlyPriceMapper, times(1))
+                    .getPriceDuration(productCode, previousMonthYear, 1, previousMonthYear, previousMonth);
+        }
+
+        @Test
+        @DisplayName("다른 productCode는 별도 캐시 키 → 각각 매퍼 호출")
+        void 다른productCode_별도캐시키() {
+            String productCode1 = "PROD001";
+            String productCode2 = "PROD002";
+
+            given(monthlyPriceMapper.getPriceDuration(productCode1, 2024, 1, 2024, 6))
+                    .willReturn(Collections.emptyList());
+            given(monthlyPriceMapper.getPriceDuration(productCode2, 2024, 1, 2024, 6))
+                    .willReturn(Collections.emptyList());
+
+            monthlyPriceService.getMonthlyPrices(productCode1, 2024, 1, 2024, 6);
+            monthlyPriceService.getMonthlyPrices(productCode2, 2024, 1, 2024, 6);
+
+            verify(monthlyPriceMapper, times(1)).getPriceDuration(productCode1, 2024, 1, 2024, 6);
+            verify(monthlyPriceMapper, times(1)).getPriceDuration(productCode2, 2024, 1, 2024, 6);
+        }
     }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/ProductServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/ProductServiceTest.java
@@ -19,8 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -28,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@Transactional
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
 

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/ProductServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/ProductServiceTest.java
@@ -2,17 +2,27 @@ package com.yachaerang.backend.api.product.service;
 
 import com.yachaerang.backend.api.product.dto.response.ProductResponseDto;
 import com.yachaerang.backend.api.product.repository.ProductMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -81,7 +91,6 @@ class ProductServiceTest {
         verify(productMapper).findAllItemNameAndItemCodes();
         verifyNoMoreInteractions(productMapper);
     }
-
 
     @Test
     @DisplayName("제품 목록 하위부류까지 반환 성공")
@@ -188,5 +197,110 @@ class ProductServiceTest {
 
         // then
         verify(productMapper).findProductNameByItemCode(eq("ITEM001"));
+    }
+
+    // ─── 캐시 레이어 테스트 ────────────────────────────────────────────────────
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = CacheLayerTest.TestConfig.class)
+    class CacheLayerTest {
+
+        @Configuration
+        @EnableCaching
+        static class TestConfig {
+
+            @Bean
+            public CacheManager cacheManager() {
+                return new ConcurrentMapCacheManager("product:itemNames", "product:subItems");
+            }
+
+            @Bean
+            public ProductMapper productMapper() {
+                return Mockito.mock(ProductMapper.class);
+            }
+
+            @Bean
+            public ProductService productService(ProductMapper productMapper) {
+                return new ProductService(productMapper);
+            }
+        }
+
+        @Autowired
+        ProductMapper productMapper;
+
+        @Autowired
+        ProductService productService;
+
+        @Autowired
+        CacheManager cacheManager;
+
+        @BeforeEach
+        void resetMocksAndCaches() {
+            Mockito.reset(productMapper);
+            cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+        }
+
+        @Test
+        @DisplayName("getItemNames: 두 번 호출해도 매퍼 1회만 호출 (캐시 히트)")
+        void getItemNames_두번호출_캐시히트() {
+            List<ProductResponseDto.ItemDto> data = List.of(
+                    ProductResponseDto.ItemDto.builder().itemCode("ITEM001").itemName("과일").build()
+            );
+            given(productMapper.findAllItemNameAndItemCodes()).willReturn(data);
+
+            productService.getItemNames();
+            productService.getItemNames();
+
+            verify(productMapper, times(1)).findAllItemNameAndItemCodes();
+        }
+
+        @Test
+        @DisplayName("getProductNames: 동일 itemCode 반복 호출 시 매퍼 1회만 호출 (캐시 히트)")
+        void getProductNames_동일itemCode_캐시히트() {
+            String itemCode = "ITEM001";
+            List<ProductResponseDto.SubItemDto> data = List.of(
+                    ProductResponseDto.SubItemDto.builder()
+                            .productCode("PROD001").name("사과").itemCode(itemCode)
+                            .itemName("과일").kindName("사과").kindCode("K001")
+                            .productRank("특").rankCode("R001").build()
+            );
+            given(productMapper.findProductNameByItemCode(itemCode)).willReturn(data);
+
+            productService.getProductNames(itemCode);
+            productService.getProductNames(itemCode);
+
+            verify(productMapper, times(1)).findProductNameByItemCode(itemCode);
+        }
+
+        @Test
+        @DisplayName("getProductNames: 다른 itemCode는 별도 캐시 키 → 각각 매퍼 호출")
+        void getProductNames_다른itemCode_별도캐시키() {
+            String itemCode1 = "ITEM001";
+            String itemCode2 = "ITEM002";
+
+            given(productMapper.findProductNameByItemCode(itemCode1)).willReturn(Collections.emptyList());
+            given(productMapper.findProductNameByItemCode(itemCode2)).willReturn(Collections.emptyList());
+
+            productService.getProductNames(itemCode1);
+            productService.getProductNames(itemCode2);
+
+            verify(productMapper, times(1)).findProductNameByItemCode(itemCode1);
+            verify(productMapper, times(1)).findProductNameByItemCode(itemCode2);
+        }
+
+        @Test
+        @DisplayName("getItemNames 캐시와 getProductNames 캐시는 독립적으로 동작")
+        void itemNames캐시와_subItems캐시_독립동작() {
+            given(productMapper.findAllItemNameAndItemCodes()).willReturn(Collections.emptyList());
+            given(productMapper.findProductNameByItemCode(anyString())).willReturn(Collections.emptyList());
+
+            productService.getItemNames();
+            productService.getItemNames();       // 캐시 히트
+            productService.getProductNames("ITEM001");
+            productService.getProductNames("ITEM001"); // 캐시 히트
+
+            verify(productMapper, times(1)).findAllItemNameAndItemCodes();
+            verify(productMapper, times(1)).findProductNameByItemCode("ITEM001");
+        }
     }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/WeeklyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/WeeklyPriceServiceTest.java
@@ -1,30 +1,38 @@
 package com.yachaerang.backend.api.product.service;
 
 import com.yachaerang.backend.api.product.dto.response.WeeklyPriceResponseDto;
-import com.yachaerang.backend.api.product.entity.WeeklyPrice;
 import com.yachaerang.backend.api.product.repository.WeeklyPriceMapper;
 import com.yachaerang.backend.global.exception.CustomException;
 import com.yachaerang.backend.global.exception.GeneralException;
 import com.yachaerang.backend.global.response.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.WeekFields;
-import java.util.List;
-
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @Transactional
@@ -134,7 +142,6 @@ class WeeklyPriceServiceTest {
                 });
         verify(weeklyPriceMapper, never()).getPriceDuration(any(), any(), any());
     }
-
 
     @Test
     @DisplayName("주간의 시작일과 종료일 성공")
@@ -429,5 +436,109 @@ class WeeklyPriceServiceTest {
                 });
 
         verify(weeklyPriceMapper, never()).getPriceDuration(any(), any(), any());
+    }
+
+    // ─── 캐시 레이어 테스트 ────────────────────────────────────────────────────
+    // WeeklyPriceService 캐시 조건: endDate.isBefore(now)
+    // 서비스 자체 검증: endDate.isAfter(today) → 예외 발생
+    // → endDate == today(일요일)일 때만 캐시 미적용 시나리오가 유효하므로, 과거 주간(캐시 적용)만 검증
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = WeeklyPriceServiceTest.CacheLayerTest.TestConfig.class)
+    class CacheLayerTest {
+
+        @Configuration
+        @EnableCaching
+        static class TestConfig {
+
+            @Bean
+            public CacheManager cacheManager() {
+                return new ConcurrentMapCacheManager("weekly:price");
+            }
+
+            @Bean
+            public WeeklyPriceMapper weeklyPriceMapper() {
+                return Mockito.mock(WeeklyPriceMapper.class);
+            }
+
+            @Bean
+            public WeeklyPriceService weeklyPriceService(WeeklyPriceMapper weeklyPriceMapper) {
+                return new WeeklyPriceService(weeklyPriceMapper);
+            }
+        }
+
+        @Autowired
+        WeeklyPriceMapper weeklyPriceMapper;
+
+        @Autowired
+        WeeklyPriceService weeklyPriceService;
+
+        @Autowired
+        CacheManager cacheManager;
+
+        // 2025-11-10(월) ~ 2025-11-16(일): 과거 주간, 날짜 검증 통과
+        private static final LocalDate PAST_START = LocalDate.of(2025, 11, 10);
+        private static final LocalDate PAST_END = LocalDate.of(2025, 11, 16);
+
+        @BeforeEach
+        void resetMocksAndCaches() {
+            Mockito.reset(weeklyPriceMapper);
+            cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+        }
+
+        @Test
+        @DisplayName("과거 주간 조회: 두 번째 호출은 캐시에서 반환 (매퍼 1회 호출)")
+        void 과거주간_두번째호출_캐시히트() {
+            String productCode = "PROD001";
+            List<WeeklyPriceResponseDto.PriceRecordDto> data = List.of(
+                    WeeklyPriceResponseDto.PriceRecordDto.builder()
+                            .startDate(PAST_START).endDate(PAST_END)
+                            .avgPrice(10000L).minPrice(8000L).maxPrice(12000L).build()
+            );
+            given(weeklyPriceMapper.getPriceDuration(productCode, PAST_START, PAST_END)).willReturn(data);
+
+            weeklyPriceService.getPriceDuration(productCode, PAST_START, PAST_END); // 캐시 미스
+            weeklyPriceService.getPriceDuration(productCode, PAST_START, PAST_END); // 캐시 히트
+
+            verify(weeklyPriceMapper, times(1)).getPriceDuration(productCode, PAST_START, PAST_END);
+        }
+
+        @Test
+        @DisplayName("다른 productCode는 별도 캐시 키 → 각각 매퍼 호출")
+        void 다른productCode_별도캐시키() {
+            String productCode1 = "PROD001";
+            String productCode2 = "PROD002";
+
+            given(weeklyPriceMapper.getPriceDuration(productCode1, PAST_START, PAST_END))
+                    .willReturn(Collections.emptyList());
+            given(weeklyPriceMapper.getPriceDuration(productCode2, PAST_START, PAST_END))
+                    .willReturn(Collections.emptyList());
+
+            weeklyPriceService.getPriceDuration(productCode1, PAST_START, PAST_END);
+            weeklyPriceService.getPriceDuration(productCode2, PAST_START, PAST_END);
+
+            verify(weeklyPriceMapper, times(1)).getPriceDuration(productCode1, PAST_START, PAST_END);
+            verify(weeklyPriceMapper, times(1)).getPriceDuration(productCode2, PAST_START, PAST_END);
+        }
+
+        @Test
+        @DisplayName("다른 기간은 별도 캐시 키 → 각각 매퍼 호출")
+        void 다른기간_별도캐시키() {
+            String productCode = "PROD001";
+            // 2025-11-03(월) ~ 2025-11-09(일): 또 다른 과거 주간
+            LocalDate otherStart = LocalDate.of(2025, 11, 3);
+            LocalDate otherEnd = LocalDate.of(2025, 11, 9);
+
+            given(weeklyPriceMapper.getPriceDuration(productCode, PAST_START, PAST_END))
+                    .willReturn(Collections.emptyList());
+            given(weeklyPriceMapper.getPriceDuration(productCode, otherStart, otherEnd))
+                    .willReturn(Collections.emptyList());
+
+            weeklyPriceService.getPriceDuration(productCode, PAST_START, PAST_END);
+            weeklyPriceService.getPriceDuration(productCode, otherStart, otherEnd);
+
+            verify(weeklyPriceMapper, times(1)).getPriceDuration(productCode, PAST_START, PAST_END);
+            verify(weeklyPriceMapper, times(1)).getPriceDuration(productCode, otherStart, otherEnd);
+        }
     }
 }

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/WeeklyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/WeeklyPriceServiceTest.java
@@ -22,8 +22,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.WeekFields;
@@ -35,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@Transactional
 @ExtendWith(MockitoExtension.class)
 class WeeklyPriceServiceTest {
 

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/YearlyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/YearlyPriceServiceTest.java
@@ -19,8 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +28,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@Transactional
 @ExtendWith(MockitoExtension.class)
 class YearlyPriceServiceTest {
 

--- a/backend/src/test/java/com/yachaerang/backend/api/product/service/YearlyPriceServiceTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/api/product/service/YearlyPriceServiceTest.java
@@ -1,34 +1,35 @@
 package com.yachaerang.backend.api.product.service;
 
-import com.yachaerang.backend.api.product.dto.response.MonthlyPriceResponseDto;
 import com.yachaerang.backend.api.product.dto.response.YearlyPriceResponseDto;
 import com.yachaerang.backend.api.product.repository.YearlyPriceMapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 @Transactional
 @ExtendWith(MockitoExtension.class)
 class YearlyPriceServiceTest {
@@ -161,5 +162,126 @@ class YearlyPriceServiceTest {
 
         verify(yearlyPriceMapper, times(1))
                 .getPriceSpecification(productCode, targetYear);
+    }
+
+    // ─── 캐시 레이어 테스트 ────────────────────────────────────────────────────
+    // getPrices  캐시 조건: endYear < now().year
+    // getPrice   캐시 조건: targetYear < now().year
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = CacheLayerTest.TestConfig.class)
+    class CacheLayerTest {
+
+        @Configuration
+        @EnableCaching
+        static class TestConfig {
+
+            @Bean
+            public CacheManager cacheManager() {
+                return new ConcurrentMapCacheManager("yearly:price");
+            }
+
+            @Bean
+            public YearlyPriceMapper yearlyPriceMapper() {
+                return Mockito.mock(YearlyPriceMapper.class);
+            }
+
+            @Bean
+            public YearlyPriceService yearlyPriceService(YearlyPriceMapper yearlyPriceMapper) {
+                return new YearlyPriceService(yearlyPriceMapper);
+            }
+        }
+
+        @Autowired
+        YearlyPriceMapper yearlyPriceMapper;
+
+        @Autowired
+        YearlyPriceService yearlyPriceService;
+
+        @Autowired
+        CacheManager cacheManager;
+
+        private final int currentYear = LocalDate.now().getYear();
+        private final int pastYear = currentYear - 2;
+
+        @BeforeEach
+        void resetMocksAndCaches() {
+            Mockito.reset(yearlyPriceMapper);
+            cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+        }
+
+        @Test
+        @DisplayName("getPrices: 과거 endYear 기간 조회 시 두 번째 호출은 캐시에서 반환 (매퍼 1회 호출)")
+        void getPrices_과거endYear_캐시히트() {
+            String productCode = "PROD001";
+            // endYear(pastYear) < currentYear → 조건 충족 → 캐시 적용
+            given(yearlyPriceMapper.getPriceDuration(productCode, pastYear - 1, pastYear))
+                    .willReturn(Collections.emptyList());
+
+            yearlyPriceService.getPrices(productCode, pastYear - 1, pastYear);
+            yearlyPriceService.getPrices(productCode, pastYear - 1, pastYear);
+
+            verify(yearlyPriceMapper, times(1)).getPriceDuration(productCode, pastYear - 1, pastYear);
+        }
+
+        @Test
+        @DisplayName("getPrices: 올해 endYear 기간 조회 시 캐시 조건 미충족으로 매퍼 매번 호출")
+        void getPrices_올해endYear_캐시조건_미충족() {
+            String productCode = "PROD001";
+            // endYear == currentYear → 조건 미충족 → 캐시 미적용
+            given(yearlyPriceMapper.getPriceDuration(productCode, pastYear, currentYear))
+                    .willReturn(Collections.emptyList());
+
+            yearlyPriceService.getPrices(productCode, pastYear, currentYear);
+            yearlyPriceService.getPrices(productCode, pastYear, currentYear);
+
+            verify(yearlyPriceMapper, times(2)).getPriceDuration(productCode, pastYear, currentYear);
+        }
+
+        @Test
+        @DisplayName("getPrice: 과거 targetYear 조회 시 두 번째 호출은 캐시에서 반환 (매퍼 1회 호출)")
+        void getPrice_과거targetYear_캐시히트() {
+            String productCode = "PROD001";
+            // targetYear(pastYear) < currentYear → 조건 충족 → 캐시 적용
+            YearlyPriceResponseDto.PriceDto dto = YearlyPriceResponseDto.PriceDto.builder()
+                    .priceYear(pastYear).avgPrice(100000L).build();
+            given(yearlyPriceMapper.getPriceSpecification(productCode, pastYear)).willReturn(dto);
+
+            yearlyPriceService.getPrice(productCode, pastYear);
+            yearlyPriceService.getPrice(productCode, pastYear);
+
+            verify(yearlyPriceMapper, times(1)).getPriceSpecification(productCode, pastYear);
+        }
+
+        @Test
+        @DisplayName("getPrice: 올해 targetYear 조회 시 캐시 조건 미충족으로 매퍼 매번 호출")
+        void getPrice_올해targetYear_캐시조건_미충족() {
+            String productCode = "PROD001";
+            // targetYear == currentYear → 조건 미충족 → 캐시 미적용
+            given(yearlyPriceMapper.getPriceSpecification(productCode, currentYear)).willReturn(null);
+
+            yearlyPriceService.getPrice(productCode, currentYear);
+            yearlyPriceService.getPrice(productCode, currentYear);
+
+            verify(yearlyPriceMapper, times(2)).getPriceSpecification(productCode, currentYear);
+        }
+
+        @Test
+        @DisplayName("getPrices와 getPrice는 같은 캐시('yearly:price')를 공유하지 않음 (키가 다름)")
+        void getPrices와_getPrice_캐시키_독립성() {
+            String productCode = "PROD001";
+            // getPrices 키: "PROD001:2022:2023", getPrice 키: "PROD001:2022" → 서로 다른 키
+            given(yearlyPriceMapper.getPriceDuration(productCode, pastYear, pastYear))
+                    .willReturn(Collections.emptyList());
+            given(yearlyPriceMapper.getPriceSpecification(productCode, pastYear)).willReturn(null);
+
+            yearlyPriceService.getPrices(productCode, pastYear, pastYear);
+            yearlyPriceService.getPrices(productCode, pastYear, pastYear); // 캐시 히트
+            yearlyPriceService.getPrice(productCode, pastYear);
+            yearlyPriceService.getPrice(productCode, pastYear);            // 캐시 히트
+
+            verify(yearlyPriceMapper, times(1)).getPriceDuration(productCode, pastYear, pastYear);
+            verify(yearlyPriceMapper, times(1)).getPriceSpecification(productCode, pastYear);
+        }
     }
 }

--- a/backend/src/test/java/com/yachaerang/backend/global/auth/jwt/AuthenticatedMemberProviderTest.java
+++ b/backend/src/test/java/com/yachaerang/backend/global/auth/jwt/AuthenticatedMemberProviderTest.java
@@ -144,4 +144,27 @@ class AuthenticatedMemberProviderTest {
         assertThatThrownBy(() -> authenticatedMemberProvider.getCurrentMemberId())
                 .isInstanceOf(GeneralException.class);
     }
+
+    @Test
+    @DisplayName("UsernamePasswordAuthenticationToken이면 isAuthenticated는 true")
+    void isAuthenticated_인증된_경우_true() {
+        // given
+        Member member = Member.builder().id(1L).email("test@example.com").build();
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                member, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when & then
+        assertThat(authenticatedMemberProvider.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("UsernamePasswordAuthenticationToken이 아니면 isAuthenticated는 false")
+    void isAuthenticated_미인증_경우_false() {
+        // given
+        SecurityContextHolder.getContext().setAuthentication(null);
+
+        // when & then
+        assertThat(authenticatedMemberProvider.isAuthenticated()).isFalse();
+    }
 }

--- a/batch/build.gradle
+++ b/batch/build.gradle
@@ -58,8 +58,10 @@ dependencies {
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // prometheus
+    // Metric
     implementation 'io.micrometer:micrometer-registry-prometheus-simpleclient'
+
+    // pushgateway
     implementation 'io.prometheus:simpleclient_pushgateway'
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Close #160 

## 📝 기능 설명

- 기존 token 저장소로 사용 중인 Redis를 캐시 레이어로 확장 적용하여 조회 성능을 개선했습니다.
- Local Cache(Caffeine) 대신 Redis를 선택한 이유:
    - 로컬 캐시는 멀티 인스턴스 환경에서 캐시 무효화가 어려움 (특히 지금 batch 서버 따로 돌아가고 있는데 무효화 필요할 때 어려움 )
    - 잘못된 데이터 발생 시 **Redis Pub/Sub**을 통해 전역 캐시 무효화 가능
    - 기존에 Redis를 사용 중이므로 운영 복잡도 증가 없이 재사용 가능

## 🛠 작업 사항

- **RedisConfg**에 cahceManager 추가
```java
    @Bean
    public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
        ObjectMapper cacheMapper = new ObjectMapper();
        cacheMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
        cacheMapper.registerModule(new JavaTimeModule());
        cacheMapper.activateDefaultTyping(
                LaissezFaireSubTypeValidator.instance,
                ObjectMapper.DefaultTyping.NON_FINAL,
                JsonTypeInfo.As.PROPERTY
        );

        GenericJackson2JsonRedisSerializer serializer =
                new GenericJackson2JsonRedisSerializer(cacheMapper);

        RedisCacheConfiguration defaults = RedisCacheConfiguration.defaultCacheConfig()
                .serializeValuesWith(
                        RedisSerializationContext.SerializationPair.fromSerializer(serializer))
                .disableCachingNullValues();

        Map<String, RedisCacheConfiguration> cacheConfigs = Map.of(
                "product:itemNames",  defaults.entryTtl(Duration.ofHours(24)),
                "product:subItems",   defaults.entryTtl(Duration.ofHours(24)),
                "daily:rank:high",    defaults.entryTtl(Duration.ofHours(24)),
                "daily:rank:low",     defaults.entryTtl(Duration.ofHours(24)),
                "daily:price",        defaults.entryTtl(Duration.ofDays(7)),
                "weekly:price",       defaults.entryTtl(Duration.ofDays(7)),
                "monthly:price",      defaults.entryTtl(Duration.ofDays(30)),
                "yearly:price",       defaults.entryTtl(Duration.ofDays(365))
        );

        return RedisCacheManager.builder(cf)
                .cacheDefaults(defaults)
                .withInitialCacheConfigurations(cacheConfigs)
                .build();
    }
```
- `ObjectMapper`를 활용한 JSON 직렬화 설정
- 캐시별 TTL 분리 적용

<br>

- 서비스 레이어 캐시 적용
```java
    @Cacheable(
            value = "daily:price",
            key = "#productCode + ':' + #startDate + ':' + #endDate",
            condition = "#endDate.isBefore(T(java.time.LocalDate).now())"
    )
```
- 조회 API에 @Cacheable을 적용하여 가격 데이터를 캐싱하도록 구성했습니다.
- 과거 데이터만 캐싱하도록 조건을 추가하여 데이터 정합성 유지

<br>

- **성능 개선결과(k6)**

구분 | p90 | p95 | max
-- | -- | -- | --
캐시 도입 전 | 35.0ms | 43.9ms | 286.9ms
캐시 도입 후 | 8.8ms | 10.0ms | 32.9ms

<br>

## ✅ 작업 항목
- [x] Redis CacheManager 설정 추가
- [x] 서비스 레이어 캐시 적용
- [x] 성능 테스트 및 검증

## 📎 참고 자료(선택)
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->

## 💬리뷰 요구사항(선택)
- 현재 batch에서 타임아웃 관련 설정이 충돌이 있어서 다음 이슈로 작업 후 올릴 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 제품·일·주·월·연 단위 가격 조회에 Redis 기반 캐싱 적용으로 응답 속도 및 서버 부담 개선
  * 배치 타임아웃을 10초에서 60초로 늘려 배치 안정성 향상
  * 일별 고/저가 랭킹이 어제 기준(한국시간)으로 일관되게 계산되도록 개선

* **기타**
  * 개발 환경 안전성 향상: .env 파일을 무시하도록 업데이트
  * 빌드 스크립트 주석 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->