### PR TITLE
[FIX] Batch 작업에 대한 에러 처리 세분화

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,11 @@ frontend/src
 | **Frontend** | Vue 3, JavaScript, Tailwind CSS, Axios                      |
 | **Backend**  | Spring Boot 3.5.7, Spring AI, Spring Batch, MyBatis, Gradle |
 | **Database** | MySQL 8.0.33, Redis                                         |
+| **Monitoring** | Prometheus, Grafana                                       |
+| **Testing** | k6                                                           |
 | **CI/CD**    | Github Actions                                              |
 | **API Docs** | Notion, REST Docs                                           |
 | **Infra**    | AWS EC2, AWS RDS, AWS S3, Docker, Nginx                     |
-
 <br>
 
 ---

--- a/batch/src/main/java/com/yachaerang/batch/configuration/AsyncBatchConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/AsyncBatchConfig.java
@@ -12,9 +12,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @EnableAsync
 public class AsyncBatchConfig {
 
-    private static final int CORE_POOL_SIZE = 5;
+    private static final int CORE_POOL_SIZE = 10;
     private static final int MAX_POOL_SIZE = 20;
-    private static final int QUEUE_CAPACITY = 50;
+    private static final int QUEUE_CAPACITY = 100;
     private static final int KEEP_ALIVE_SEC = 30;
 
     @Bean

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/DailyPriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/DailyPriceJobConfig.java
@@ -1,12 +1,13 @@
 package com.yachaerang.batch.configuration.job;
 
-import com.yachaerang.batch.configuration.parameter.DailyJobParameter;
 import com.yachaerang.batch.domain.dailyPrice.processor.DailyPriceProcessor;
 import com.yachaerang.batch.domain.dailyPrice.reader.DailyPriceReader;
 import com.yachaerang.batch.domain.dailyPrice.writer.DailyPriceWriter;
 import com.yachaerang.batch.domain.dto.KamisPriceItem;
 import com.yachaerang.batch.domain.entity.DailyPrice;
+import com.yachaerang.batch.listener.ItemSkipListener;
 import com.yachaerang.batch.listener.JobCompletionListener;
+import com.yachaerang.batch.listener.MdcStepListener;
 import com.yachaerang.batch.listener.StepExecutionListener;
 import com.yachaerang.batch.repository.DailyPriceRepository;
 import com.yachaerang.batch.repository.ProductRepository;
@@ -18,15 +19,21 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.partition.support.Partitioner;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /*
 Daily Price Job에 대한 설정
@@ -40,74 +47,121 @@ public class DailyPriceJobConfig {
     private final PlatformTransactionManager platformTransactionManager;
     private final JobCompletionListener jobCompletionListener;
     private final StepExecutionListener stepExecutionListener;
+    private final MdcStepListener mdcStepListener;
+    private final ItemSkipListener itemSkipListener;
 
     private final KamisApiService kamisApiService;
     private final ProductRepository productRepository;
     private final DailyPriceRepository dailyPriceRepository;
+    private final ThreadPoolTaskExecutor batchTaskExecutor;
 
     private static final int CHUNK_SIZE = 500;
     private static final List<String> CATEGORY_CODES = List.of("100", "200", "300", "400", "500", "600");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     /**
-     * Job: 카테고리 100, 200, 300, 400, 500, 600 순차 실행(categoryCode)
+     * Job: 카테고리
      */
     @Bean
     public Job dailyPriceJob() {
         return new JobBuilder("dailyPriceJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
                 .listener(jobCompletionListener)
-                .start(dailyPriceStep())
+                .start(dailyPricePartitionStep())
                 .build();
     }
 
     /**
-     * 카테고리별 Step 생성(Job의 Step)
+     * Master Step: 카테고리별 파티셔닝
      */
-    private Step dailyPriceStep() {
-        return new StepBuilder("dailyPriceStep", jobRepository)
+    @Bean
+    public Step dailyPricePartitionStep() {
+        return new StepBuilder("dailyPricePartitionStep", jobRepository)
+                .partitioner("dailyCategoryPartitioner", dailyCategoryPartitioner(null))
+                .step(dailyPriceWorkerStep())
+                .taskExecutor(batchTaskExecutor)
+                .gridSize(CATEGORY_CODES.size())
+                .build();
+    }
+
+    /**
+     * 카테고리별 Partitioner
+     * 각 파티션에 targetDate + categoryCode 설정
+     */
+    @Bean
+    @StepScope
+    public Partitioner dailyCategoryPartitioner(
+            @Value("#{jobParameters['targetDate']}") String targetDateStr) {
+
+        LocalDate targetDate = (targetDateStr != null && !targetDateStr.isBlank())
+                ? LocalDate.parse(targetDateStr, FORMATTER)
+                : LocalDate.now().minusDays(1);
+
+        return gridSize -> {
+            Map<String, ExecutionContext> partitions = new HashMap<>();
+            log.info("카테고리 파티셔닝 시작: targetDate={}, categories={}", targetDate, CATEGORY_CODES);
+
+            for (int i = 0; i < CATEGORY_CODES.size(); i++) {
+                ExecutionContext context = new ExecutionContext();
+                context.putString("targetDate", targetDate.format(FORMATTER));
+                context.putString("categoryCode", CATEGORY_CODES.get(i));
+                partitions.put("partition" + i, context);
+            }
+
+            log.info("총 {} 개의 카테고리 파티션 생성", partitions.size());
+            return partitions;
+        };
+    }
+
+    /**
+     * Worker Step: 각 카테고리 파티션 처리
+     */
+    @Bean
+    public Step dailyPriceWorkerStep() {
+        return new StepBuilder("dailyPriceWorkerStep", jobRepository)
                 .listener(stepExecutionListener)
+                .listener(mdcStepListener)
                 .<KamisPriceItem, DailyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
-                .reader(dailyPriceReader(null))
-                .processor(dailyPriceProcessor(null))
+                .reader(dailyPriceReader(null, null))
+                .processor(dailyPriceProcessor(null, null))
                 .writer(dailyPriceWriter())
                 .faultTolerant()
                 .skipLimit(10)
                 .skip(Exception.class)
+                .listener(itemSkipListener)
                 .build();
     }
 
     /**
-     * Reader 스텝
-     * @param dailyJobParameter : jobParameters에서 얻어오기
-     * @return
+     * Reader: stepExecutionContext에서 targetDate, categoryCode 읽기
      */
     @Bean
     @StepScope
-    public DailyPriceReader dailyPriceReader(DailyJobParameter dailyJobParameter) {
+    public DailyPriceReader dailyPriceReader(
+            @Value("#{stepExecutionContext['targetDate']}") String targetDateStr,
+            @Value("#{stepExecutionContext['categoryCode']}") String categoryCode) {
 
-        LocalDate targetDate = dailyJobParameter.getTargetDate();
+        LocalDate targetDate = LocalDate.parse(targetDateStr, FORMATTER);
 
-        log.info("Reader 생성: targetDate={}", targetDate);
+        log.info("Reader 생성: targetDate={}, categoryCode={}", targetDate, categoryCode);
 
-        return new DailyPriceReader(kamisApiService, targetDate, CATEGORY_CODES);
+        return new DailyPriceReader(kamisApiService, targetDate, categoryCode);
     }
 
     /**
-     * Processor Step
-     * @param dailyJobParameter : jobParameter로부터 얻음 (category는 reader에서 필터링)
-     * @return
+     * Processor: stepExecutionContext에서 targetDate 읽기
      */
     @Bean
     @StepScope
-    public DailyPriceProcessor dailyPriceProcessor(DailyJobParameter dailyJobParameter) {
+    public DailyPriceProcessor dailyPriceProcessor(
+            @Value("#{stepExecutionContext['targetDate']}") String targetDateStr,
+            @Value("#{stepExecutionContext['categoryCode']}") String categoryCode) {
 
-        LocalDate targetDate = dailyJobParameter.getTargetDate();
+        LocalDate targetDate = LocalDate.parse(targetDateStr, FORMATTER);
 
-        return new DailyPriceProcessor(
-                productRepository,
-                dailyPriceRepository,
-                targetDate
-        );
+        log.info("Processor 생성: targetDate={}, categoryCode={}", targetDate, categoryCode);
+
+        return new DailyPriceProcessor(productRepository, dailyPriceRepository, targetDate);
     }
 
     /*
@@ -116,15 +170,5 @@ public class DailyPriceJobConfig {
     @Bean
     public DailyPriceWriter dailyPriceWriter() {
         return new DailyPriceWriter(dailyPriceRepository);
-    }
-
-    /*
-    형식 맞춰서 찾기
-     */
-    private LocalDate parseTargetDate(String targetDateStr) {
-        if (targetDateStr == null || targetDateStr.isBlank()) {
-            return LocalDate.now().minusDays(1);
-        }
-        return LocalDate.parse(targetDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 }

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/DateRangePriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/DateRangePriceJobConfig.java
@@ -5,7 +5,10 @@ import com.yachaerang.batch.domain.dailyPrice.reader.DailyPriceReader;
 import com.yachaerang.batch.domain.dailyPrice.writer.DailyPriceWriter;
 import com.yachaerang.batch.domain.dto.KamisPriceItem;
 import com.yachaerang.batch.domain.entity.DailyPrice;
+import com.yachaerang.batch.listener.ItemSkipListener;
 import com.yachaerang.batch.listener.JobCompletionListener;
+import com.yachaerang.batch.listener.MdcStepListener;
+import com.yachaerang.batch.listener.StepExecutionListener;
 import com.yachaerang.batch.repository.DailyPriceRepository;
 import com.yachaerang.batch.repository.ProductRepository;
 import com.yachaerang.batch.service.KamisApiService;
@@ -43,6 +46,9 @@ public class DateRangePriceJobConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final JobCompletionListener jobCompletionListener;
+    private final StepExecutionListener stepExecutionListener;
+    private final MdcStepListener mdcStepListener;
+    private final ItemSkipListener itemSkipListener;
 
     private final KamisApiService kamisApiService;
     private final ProductRepository productRepository;
@@ -74,12 +80,12 @@ public class DateRangePriceJobConfig {
                 .partitioner("dailyStepPartitioner", dateRangePartitioner(null, null))
                 .step(partitionedPriceStep())
                 .taskExecutor(batchTaskExecutor)
-                .gridSize(10)
+                .gridSize(CATEGORY_CODES.size())
                 .build();
     }
 
     /*
-    날짜 범위 기반의 Partitioner - 시작일 ~ 종료일 범위
+    날짜 범위 기반의 Partitioner
      */
     @Bean
     @StepScope
@@ -91,22 +97,24 @@ public class DateRangePriceJobConfig {
             Map<String, ExecutionContext> partitions = new HashMap<>();
             LocalDate startDate = LocalDate.parse(startDateStr, FORMATTER);
             LocalDate endDate = LocalDate.parse(endDateStr, FORMATTER);
-            log.info("Start Partitioning: {} ~ {}", startDate, endDate);
+            log.info("Start Partitioning: {} ~ {}, categories={}", startDate, endDate, CATEGORY_CODES);
 
             LocalDate currentDate = startDate;
             int partitionNumber = 0;
 
-            // endDate까지 반복
+            // endDate까지 날짜 × 카테고리 파티션 생성
             while (!currentDate.isAfter(endDate)) {
-                ExecutionContext context = new ExecutionContext();
-                context.putString("targetDate", currentDate.format(FORMATTER));
-                context.putInt("partitionNumber", partitionNumber);
-                partitions.put("partition" + partitionNumber, context);
-
+                for (String categoryCode : CATEGORY_CODES) {
+                    ExecutionContext context = new ExecutionContext();
+                    context.putString("targetDate", currentDate.format(FORMATTER));
+                    context.putString("categoryCode", categoryCode);
+                    context.putInt("partitionNumber", partitionNumber);
+                    partitions.put("partition" + partitionNumber, context);
+                    partitionNumber++;
+                }
                 currentDate = currentDate.plusDays(1);
-                partitionNumber++;
             }
-            log.info("Total {} 개의 Partitions 생성", partitions.size());
+            log.info("Total {} 개의 Partitions 생성 (날짜 × 카테고리)", partitions.size());
             return partitions;
         };
     }
@@ -118,12 +126,15 @@ public class DateRangePriceJobConfig {
     public Step partitionedPriceStep() {
         return new StepBuilder("partitionedPriceStep", jobRepository)
                 .<KamisPriceItem, DailyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
-                .reader(partitionedPriceReader(null))
+                .listener(stepExecutionListener)
+                .listener(mdcStepListener)
+                .reader(partitionedPriceReader(null, null))
                 .processor(partitionedPriceProcessor(null))
                 .writer(partitionedPriceWriter())
                 .faultTolerant()
                 .skipLimit(10)
                 .skip(Exception.class)
+                .listener(itemSkipListener)
                 .retryLimit(3)
                 .retry(Exception.class)
                 .build();
@@ -135,13 +146,14 @@ public class DateRangePriceJobConfig {
     @Bean
     @StepScope
     public DailyPriceReader partitionedPriceReader(
-            @Value("#{stepExecutionContext['targetDate']}") String targetDateStr) {
+            @Value("#{stepExecutionContext['targetDate']}") String targetDateStr,
+            @Value("#{stepExecutionContext['categoryCode']}") String categoryCode) {
 
         LocalDate targetDate = LocalDate.parse(targetDateStr);
 
-        log.info("PartitionedReader 생성: targetDate={}, categories={}", targetDate, CATEGORY_CODES);
+        log.info("PartitionedReader 생성: targetDate={}, categoryCode={}", targetDate, categoryCode);
 
-        return new DailyPriceReader(kamisApiService, targetDate, CATEGORY_CODES);
+        return new DailyPriceReader(kamisApiService, targetDate, categoryCode);
     }
 
     /*

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/MonthlyPriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/MonthlyPriceJobConfig.java
@@ -3,7 +3,9 @@ package com.yachaerang.batch.configuration.job;
 import com.yachaerang.batch.configuration.parameter.JobPeriodParameter;
 import com.yachaerang.batch.domain.entity.MonthlyPrice;
 import com.yachaerang.batch.domain.processor.MonthlyPriceProcessor;
+import com.yachaerang.batch.listener.ItemSkipListener;
 import com.yachaerang.batch.listener.JobCompletionListener;
+import com.yachaerang.batch.listener.MdcStepListener;
 import com.yachaerang.batch.listener.StepExecutionListener;
 import com.yachaerang.batch.repository.DailyPriceRepository;
 import com.yachaerang.batch.service.MonthlyPriceAggregationService;
@@ -35,6 +37,8 @@ public class MonthlyPriceJobConfig {
     private final PlatformTransactionManager platformTransactionManager;
     private final JobCompletionListener jobCompletionListener;
     private final StepExecutionListener stepExecutionListener;
+    private final MdcStepListener mdcStepListener;
+    private final ItemSkipListener itemSkipListener;
 
     private final MonthlyPriceAggregationService monthlyPriceAggregationService;
     private final DailyPriceRepository dailyPriceRepository;
@@ -63,10 +67,14 @@ public class MonthlyPriceJobConfig {
         return new StepBuilder("monthlyPriceStep", jobRepository)
                 .<MonthlyPrice, MonthlyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
                 .listener(stepExecutionListener)
+                .listener(mdcStepListener)
                 .reader(monthlyPriceReader)
                 .processor(monthlyPriceProcessor())
                 .writer(monthlyPriceWriter)
                 .faultTolerant()
+                .skipLimit(10)
+                .skip(Exception.class)
+                .listener(itemSkipListener)
                 .retryLimit(3)
                 .retry(Exception.class)
                 .build();

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/WeeklyPriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/WeeklyPriceJobConfig.java
@@ -3,7 +3,9 @@ package com.yachaerang.batch.configuration.job;
 import com.yachaerang.batch.configuration.parameter.JobPeriodParameter;
 import com.yachaerang.batch.domain.entity.WeeklyPrice;
 import com.yachaerang.batch.domain.processor.WeeklyPriceProcessor;
+import com.yachaerang.batch.listener.ItemSkipListener;
 import com.yachaerang.batch.listener.JobCompletionListener;
+import com.yachaerang.batch.listener.MdcStepListener;
 import com.yachaerang.batch.listener.StepExecutionListener;
 import com.yachaerang.batch.repository.DailyPriceRepository;
 import com.yachaerang.batch.service.WeeklyPriceAggregationService;
@@ -36,6 +38,8 @@ public class WeeklyPriceJobConfig {
     private final PlatformTransactionManager platformTransactionManager;
     private final JobCompletionListener jobCompletionListener;
     private final StepExecutionListener stepExecutionListener;
+    private final MdcStepListener mdcStepListener;
+    private final ItemSkipListener itemSkipListener;
 
     private final WeeklyPriceAggregationService weeklyPriceAggregationService;
     private final DailyPriceRepository dailyPriceRepository;
@@ -59,10 +63,14 @@ public class WeeklyPriceJobConfig {
         return new StepBuilder("weeklyPriceStep", jobRepository)
                 .<WeeklyPrice, WeeklyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
                 .listener(stepExecutionListener)
+                .listener(mdcStepListener)
                 .reader(weeklyPriceReader(null))
                 .processor(weeklyPriceProcessor())
                 .writer(weeklyPriceWriter())
                 .faultTolerant()
+                .skipLimit(10)
+                .skip(Exception.class)
+                .listener(itemSkipListener)
                 .retryLimit(3)
                 .retry(Exception.class)
                 .build();

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/YearlyPriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/YearlyPriceJobConfig.java
@@ -2,7 +2,9 @@ package com.yachaerang.batch.configuration.job;
 
 import com.yachaerang.batch.configuration.parameter.JobPeriodParameter;
 import com.yachaerang.batch.domain.entity.YearlyPrice;
+import com.yachaerang.batch.listener.ItemSkipListener;
 import com.yachaerang.batch.listener.JobCompletionListener;
+import com.yachaerang.batch.listener.MdcStepListener;
 import com.yachaerang.batch.listener.StepExecutionListener;
 import com.yachaerang.batch.service.YearlyPriceAggregationService;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,8 @@ public class YearlyPriceJobConfig {
     private final PlatformTransactionManager platformTransactionManager;
     private final JobCompletionListener jobCompletionListener;
     private final StepExecutionListener stepExecutionListener;
+    private final MdcStepListener mdcStepListener;
+    private final ItemSkipListener itemSkipListener;
 
     private final YearlyPriceAggregationService yearlyPriceAggregationService;
 
@@ -61,10 +65,14 @@ public class YearlyPriceJobConfig {
         return new StepBuilder("yearlyPriceStep", jobRepository)
                 .<YearlyPrice, YearlyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
                 .listener(stepExecutionListener)
+                .listener(mdcStepListener)
                 .reader(yearlyPriceReader)
                 .processor(yearlyPriceProcessor)
                 .writer(yearlyPriceWriter)
                 .faultTolerant()
+                .skipLimit(10)
+                .skip(Exception.class)
+                .listener(itemSkipListener)
                 .retryLimit(3)
                 .retry(Exception.class)
                 .build();

--- a/batch/src/main/java/com/yachaerang/batch/listener/ItemSkipListener.java
+++ b/batch/src/main/java/com/yachaerang/batch/listener/ItemSkipListener.java
@@ -1,0 +1,28 @@
+package com.yachaerang.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.SkipListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ItemSkipListener implements SkipListener<Object, Object> {
+
+    @Override
+    public void onSkipInRead(Throwable t) {
+        log.warn("Read 중 Skip 발생: exceptionClass={}, message={}",
+                t.getClass().getName(), t.getMessage());
+    }
+
+    @Override
+    public void onSkipInProcess(Object item, Throwable t) {
+        log.warn("Process 중 Skip 발생: item={}, exceptionClass={}, message={}",
+                item, t.getClass().getName(), t.getMessage());
+    }
+
+    @Override
+    public void onSkipInWrite(Object item, Throwable t) {
+        log.warn("Write 중 Skip 발생: item={}, exceptionClass={}, message={}",
+                item, t.getClass().getName(), t.getMessage());
+    }
+}

--- a/batch/src/main/java/com/yachaerang/batch/listener/JobCompletionListener.java
+++ b/batch/src/main/java/com/yachaerang/batch/listener/JobCompletionListener.java
@@ -9,45 +9,61 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-/*
-Job에 대한 Listener 구현
- */
 @Slf4j
 @Component
 public class JobCompletionListener implements JobExecutionListener {
 
-    /*
-    시작 이전의 Listener
-     */
     @Override
     public void beforeJob(JobExecution jobExecution) {
         log.info("========================================");
         log.info("Job 시작: {}", jobExecution.getJobInstance().getJobName());
+        log.info("jobExecutionId={}", jobExecution.getId());
         log.info("Job Parameters: {}", jobExecution.getJobParameters());
         log.info("시작 시간: {}", jobExecution.getStartTime());
         log.info("========================================");
     }
 
-    /*
-    종료 이후의 Listener
-     */
     @Override
     public void afterJob(JobExecution jobExecution) {
         LocalDateTime startTime = jobExecution.getStartTime();
         LocalDateTime endTime = jobExecution.getEndTime();
-
         Duration duration = Duration.between(startTime, endTime);
 
         log.info("========================================");
         log.info("Job 완료: {}", jobExecution.getJobInstance().getJobName());
-        log.info("상태: {}", jobExecution.getStatus());
+        log.info("jobExecutionId={}, status={}", jobExecution.getId(), jobExecution.getStatus());
         log.info("종료 시간: {}", endTime);
         log.info("소요 시간: {}초", duration.getSeconds());
 
         if (jobExecution.getStatus() == BatchStatus.FAILED) {
-            log.error("Job 실패 - 예외 정보:");
-            jobExecution.getAllFailureExceptions()
-                    .forEach(e -> log.error("Exception: ", e));
+            log.error("===== JOB FAILED =====");
+            log.error("jobName={}, jobExecutionId={}, status={}",
+                    jobExecution.getJobInstance().getJobName(),
+                    jobExecution.getId(),
+                    jobExecution.getStatus());
+
+            // 모든 failure exception 순회하며 root cause 탐색
+            for (Throwable ex : jobExecution.getAllFailureExceptions()) {
+                log.error("Failure exception: class={}", ex.getClass().getName(), ex);
+
+                Throwable root = ex;
+                while (root.getCause() != null) {
+                    root = root.getCause();
+                }
+                log.error("Root cause: class={}, message={}", root.getClass().getName(), root.getMessage());
+            }
+
+            // 실패한 StepExecution 상세 출력
+            jobExecution.getStepExecutions().stream()
+                    .filter(step -> step.getStatus() == BatchStatus.FAILED)
+                    .forEach(step -> log.error(
+                            "Failed step: name={}, readCount={}, writeCount={}, skipCount={}, exitDescription={}",
+                            step.getStepName(),
+                            step.getReadCount(),
+                            step.getWriteCount(),
+                            step.getSkipCount(),
+                            step.getExitStatus().getExitDescription()
+                    ));
         }
         log.info("========================================");
     }

--- a/batch/src/main/java/com/yachaerang/batch/listener/MdcStepListener.java
+++ b/batch/src/main/java/com/yachaerang/batch/listener/MdcStepListener.java
@@ -1,0 +1,25 @@
+package com.yachaerang.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MdcStepListener implements org.springframework.batch.core.StepExecutionListener {
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        MDC.put("jobExecutionId", String.valueOf(stepExecution.getJobExecutionId()));
+        MDC.put("stepName", stepExecution.getStepName());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        MDC.remove("jobExecutionId");
+        MDC.remove("stepName");
+        return stepExecution.getExitStatus();
+    }
+}

--- a/batch/src/main/java/com/yachaerang/batch/listener/StepExecutionListener.java
+++ b/batch/src/main/java/com/yachaerang/batch/listener/StepExecutionListener.java
@@ -1,33 +1,45 @@
 package com.yachaerang.batch.listener;
+
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.stereotype.Component;
 
-/*
-Step Listener (Step마다 실행)
- */
 @Slf4j
 @Component
 public class StepExecutionListener implements org.springframework.batch.core.StepExecutionListener {
 
-    /*
-    Step 시작 로그
-     */
     @Override
     public void beforeStep(StepExecution stepExecution) {
-        log.info("Step 시작: {}", stepExecution.getStepName());
+        log.info("Step 시작: name={}, jobExecutionId={}",
+                stepExecution.getStepName(),
+                stepExecution.getJobExecutionId());
     }
 
-    /*
-    Step 종료 로그
-     */
     @Override
     public ExitStatus afterStep(StepExecution stepExecution) {
-        log.info("Step 완료: {}", stepExecution.getStepName());
-        log.info(" - 읽기: {} 건", stepExecution.getReadCount());
-        log.info(" - 처리: {} 건", stepExecution.getWriteCount());
-        log.info(" - Skip: {} 건", stepExecution.getSkipCount());
+        if (stepExecution.getStatus() == BatchStatus.FAILED) {
+            log.error("Step 실패: name={}, readCount={}, writeCount={}, skipCount={}, rollbackCount={}",
+                    stepExecution.getStepName(),
+                    stepExecution.getReadCount(),
+                    stepExecution.getWriteCount(),
+                    stepExecution.getSkipCount(),
+                    stepExecution.getRollbackCount());
+
+            stepExecution.getFailureExceptions().forEach(ex ->
+                    log.error("Step failure exception: class={}, message={}",
+                            ex.getClass().getName(), ex.getMessage(), ex)
+            );
+
+            log.error("Step ExecutionContext: {}", stepExecution.getExecutionContext());
+        } else {
+            log.info("Step 완료: name={}, readCount={}, writeCount={}, skipCount={}",
+                    stepExecution.getStepName(),
+                    stepExecution.getReadCount(),
+                    stepExecution.getWriteCount(),
+                    stepExecution.getSkipCount());
+        }
         return stepExecution.getExitStatus();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Close #164 

## 📝 기능 설명

- **`문제 상황`**
- 기존 배치 작업의 경우 모니터링이 어려운 문제가 있었습니다.
    - Step 실행 중 중단될 경우 Job이 FAILED 상태로 종료되지만 로그만으로는 어떤 이유로 실패했는지, 어떤 파티션에서 Step이 중단되었는지 파악하기 어려움
- 추가로 파티셔닝 개선 여지 존재 + 현재 요청 조금만 많아도 터지는 문제

<br>

- **`해결 방법`**
- 카테고리 단위 Partitioning 적용 (병렬 처리)
- 배치 실행 흐름을 추적하기 위한 리스너 기반 로깅 추가
- 스레드 풀 사이즈 조정
 
<br>

## 🛠 작업 사항

- **Category 기준 Partitioning 추가**
```java
@Bean
@StepScope
public Partitioner dailyCategoryPartitioner(
        @Value("#{jobParameters['targetDate']}") String targetDateStr) {

    LocalDate targetDate = (targetDateStr != null && !targetDateStr.isBlank())
            ? LocalDate.parse(targetDateStr, FORMATTER)
            : LocalDate.now().minusDays(1);

    return gridSize -> {
        Map<String, ExecutionContext> partitions = new HashMap<>();
        log.info("카테고리 파티셔닝 시작: targetDate={}, categories={}", targetDate, CATEGORY_CODES);

        for (int i = 0; i < CATEGORY_CODES.size(); i++) {
            ExecutionContext context = new ExecutionContext();
            context.putString("targetDate", targetDate.format(FORMATTER));
            context.putString("categoryCode", CATEGORY_CODES.get(i));
            partitions.put("partition" + i, context);
        }

        log.info("총 {} 개의 카테고리 파티션 생성", partitions.size());
        return partitions;
    };
}
```
- 기존에는 Kamis 데이터를 100/200/300/400/500/600 순차적으로 수집하고 있었는데(날짜를 기준으로 파티셔닝했음) 이를 카테고리 단위로 파티셔닝하여 병렬 처리하도록 변경했습니다.

<br>

- `DailyPriceJobConfig` : 카테고리 기반 파티셔닝

| 항목 | 내용 |
|-- | -- |
| 파티션 기준 | 카테고리 코드 |
| 파티션 수 | 6개 (100~600) |
| 파티션 키 | targetDate + categoryCode |
| gridSize | 6 | 
| CHUNK_SIZE | 500 |
| 특이사항 | targetDate jobParameter 없으면 어제 날짜 fallback |

- `DateRangePriceJobConfig`: 날짜 * 카테고리 파티셔닝

| 항목 | 내용 |
| -- | -- |
| 파티션 기준 | 카테고리 코드 |
| 파티션 수 | 6개 (100~600) |
| 파티션 키 | targetDate + categoryCode |
| gridSize | 6 |
| CHUNK_SIZE | 500 |
| 특이사항 | targetDate jobParameter 없으면 어제 날짜 fallback |


<br>

- **`ItemSkipListener`**
```java
@Slf4j
@Component
public class ItemSkipListener implements SkipListener<Object, Object> {

    @Override
    public void onSkipInRead(Throwable t) {
        log.warn("Read 중 Skip 발생: exceptionClass={}, message={}",
                t.getClass().getName(), t.getMessage());
    }

    @Override
    public void onSkipInProcess(Object item, Throwable t) {
        log.warn("Process 중 Skip 발생: item={}, exceptionClass={}, message={}",
                item, t.getClass().getName(), t.getMessage());
    }

    @Override
    public void onSkipInWrite(Object item, Throwable t) {
        log.warn("Write 중 Skip 발생: item={}, exceptionClass={}, message={}",
                item, t.getClass().getName(), t.getMessage());
    }
}
```
- Skip 발생 시 어떤 단계(Read/Process/Write)에서 어떤 데이터가 Skip 되었는지 로그로 확인할 수 있도록 리스너를 추가

<br>

- **`MdcStepListener`**
```java
@Slf4j
@Component
public class MdcStepListener implements org.springframework.batch.core.StepExecutionListener {

    @Override
    public void beforeStep(StepExecution stepExecution) {
        MDC.put("jobExecutionId", String.valueOf(stepExecution.getJobExecutionId()));
        MDC.put("stepName", stepExecution.getStepName());
    }

    @Override
    public ExitStatus afterStep(StepExecution stepExecution) {
        MDC.remove("jobExecutionId");
        MDC.remove("stepName");
        return stepExecution.getExitStatus();
    }
}
```
- 로그에서 JobExecutionId와 StepName을 함께 기록할 수 있도록 MDC 기반 Step Listener를 추가
- 멀티 스레드 환경에서도 어떤 Step 로그인지 쉽게 추적할 수 있도록 개선

<br>

- **`JobCompletionListener`**
```java
// 실패한 StepExecution 상세 출력
jobExecution.getStepExecutions().stream()
        .filter(step -> step.getStatus() == BatchStatus.FAILED)
        .forEach(step -> log.error(
                "Failed step: name={}, readCount={}, writeCount={}, skipCount={}, exitDescription={}",
                step.getStepName(),
                step.getReadCount(),
                step.getWriteCount(),
                step.getSkipCount(),
                step.getExitStatus().getExitDescription()
        ));
```
- 기존에는 Job 실패 시 실패한 Step의 상세 로그가 남지 않는 문제가 있어 JobCompletionListener에서 실패한 Step 정보를 출력하도록 수정했습니다.


## ✅ 작업 항목
- [x] 카테고리 기반 Partitioning 적용
- [x] Skip 로그 리스너 추가
- [x] MDC 기반 Step 로그 추적
- [x] Job 실패 시 Step 상세 로그 추가
- [x] Thread Pool Size 조정

## 📎 참고 자료(선택)
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 일일 및 날짜 범위 가격 작업에 카테고리별 병렬 처리 파티셔닝 추가
  * 배치 처리 중 예외 발생 시 아이템 스킵 기능 추가 (월별, 주별, 연간 작업)
  * 작업 추적을 위한 향상된 로깅 및 모니터링 기능 추가

* **성능 개선**
  * 스레드 풀 동시성 설정 증가 (처리량 향상)

* **로깅 및 진단**
  * 작업 실행 ID, 단계명, 읽기/쓰기/스킵 통계 등의 상세 로그 추가
  * 실패 원인 추적 정보 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->