### PR TITLE
[FIX] AsyncJobLauncher와 PartitionStep executor 분리 및 파티션 큐에 블로킹 정책 적용

### DIFF
--- a/batch/src/main/java/com/yachaerang/batch/configuration/AsyncBatchConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/AsyncBatchConfig.java
@@ -14,11 +14,11 @@ public class AsyncBatchConfig {
 
     private static final int CORE_POOL_SIZE = 10;
     private static final int MAX_POOL_SIZE = 20;
-    private static final int QUEUE_CAPACITY = 100;
+    private static final int QUEUE_CAPACITY = 50;
     private static final int KEEP_ALIVE_SEC = 30;
 
     @Bean
-    public ThreadPoolTaskExecutor batchTaskExecutor() {
+    public ThreadPoolTaskExecutor jobTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(CORE_POOL_SIZE);
         executor.setMaxPoolSize(MAX_POOL_SIZE);
@@ -26,7 +26,7 @@ public class AsyncBatchConfig {
         executor.setKeepAliveSeconds(KEEP_ALIVE_SEC);
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(10);
-        executor.setThreadNamePrefix("batch-job-");
+        executor.setThreadNamePrefix("job-launcher-");
         executor.initialize();
         return executor;
     }
@@ -35,7 +35,7 @@ public class AsyncBatchConfig {
     public JobLauncher asyncJobLauncher(JobRepository jobRepository) throws Exception {
         TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
         launcher.setJobRepository(jobRepository);
-        launcher.setTaskExecutor(batchTaskExecutor());
+        launcher.setTaskExecutor(jobTaskExecutor());
         launcher.afterPropertiesSet();
         return launcher;
     }

--- a/batch/src/main/java/com/yachaerang/batch/configuration/PartitionStepConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/PartitionStepConfig.java
@@ -10,14 +10,14 @@ import java.util.concurrent.RejectedExecutionException;
 public class PartitionStepConfig {
 
     private static final int PARTITION_CORE_POOL_SIZE = 10;
-    private static final int PARTITION_MAX_POLL_SIZE = 20;
+    private static final int PARTITION_MAX_POOL_SIZE = 20;
     private static final int PARTITION_QUEUE_CAPACITY = 100;
 
     @Bean
     public ThreadPoolTaskExecutor partitionTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(PARTITION_CORE_POOL_SIZE);
-        executor.setMaxPoolSize(PARTITION_MAX_POLL_SIZE);
+        executor.setMaxPoolSize(PARTITION_MAX_POOL_SIZE);
         executor.setQueueCapacity(PARTITION_QUEUE_CAPACITY);
         executor.setThreadNamePrefix("partition-worker-");
         executor.setWaitForTasksToCompleteOnShutdown(true);

--- a/batch/src/main/java/com/yachaerang/batch/configuration/PartitionStepConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/PartitionStepConfig.java
@@ -1,0 +1,36 @@
+package com.yachaerang.batch.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.RejectedExecutionException;
+
+@Configuration
+public class PartitionStepConfig {
+
+    private static final int PARTITION_CORE_POOL_SIZE = 10;
+    private static final int PARTITION_MAX_POLL_SIZE = 20;
+    private static final int PARTITION_QUEUE_CAPACITY = 100;
+
+    @Bean
+    public ThreadPoolTaskExecutor partitionTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(PARTITION_CORE_POOL_SIZE);
+        executor.setMaxPoolSize(PARTITION_MAX_POLL_SIZE);
+        executor.setQueueCapacity(PARTITION_QUEUE_CAPACITY);
+        executor.setThreadNamePrefix("partition-worker-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.setRejectedExecutionHandler((runnable, pool) -> {
+            try {
+                pool.getQueue().put(runnable);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RejectedExecutionException("파티션 큐 대기 중 인터럽트 발생", e);
+            }
+        });
+        executor.initialize();
+        return executor;
+    }
+}

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/DailyPriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/DailyPriceJobConfig.java
@@ -53,7 +53,7 @@ public class DailyPriceJobConfig {
     private final KamisApiService kamisApiService;
     private final ProductRepository productRepository;
     private final DailyPriceRepository dailyPriceRepository;
-    private final ThreadPoolTaskExecutor batchTaskExecutor;
+    private final ThreadPoolTaskExecutor partitionTaskExecutor;
 
     private static final int CHUNK_SIZE = 500;
     private static final List<String> CATEGORY_CODES = List.of("100", "200", "300", "400", "500", "600");
@@ -79,7 +79,7 @@ public class DailyPriceJobConfig {
         return new StepBuilder("dailyPricePartitionStep", jobRepository)
                 .partitioner("dailyCategoryPartitioner", dailyCategoryPartitioner(null))
                 .step(dailyPriceWorkerStep())
-                .taskExecutor(batchTaskExecutor)
+                .taskExecutor(partitionTaskExecutor)
                 .gridSize(CATEGORY_CODES.size())
                 .build();
     }

--- a/batch/src/main/java/com/yachaerang/batch/configuration/job/DateRangePriceJobConfig.java
+++ b/batch/src/main/java/com/yachaerang/batch/configuration/job/DateRangePriceJobConfig.java
@@ -53,7 +53,7 @@ public class DateRangePriceJobConfig {
     private final KamisApiService kamisApiService;
     private final ProductRepository productRepository;
     private final DailyPriceRepository dailyPriceRepository;
-    private final ThreadPoolTaskExecutor batchTaskExecutor;
+    private final ThreadPoolTaskExecutor partitionTaskExecutor;
 
     private static final int CHUNK_SIZE = 100;
     private static final List<String> CATEGORY_CODES = List.of("100", "200", "300", "400", "500", "600");
@@ -79,7 +79,7 @@ public class DateRangePriceJobConfig {
         return new StepBuilder("dateRangePartitionStep", jobRepository)
                 .partitioner("dailyStepPartitioner", dateRangePartitioner(null, null))
                 .step(partitionedPriceStep())
-                .taskExecutor(batchTaskExecutor)
+                .taskExecutor(partitionTaskExecutor)
                 .gridSize(CATEGORY_CODES.size())
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Close #166 

## 📝 기능 설명

Spring Batch 파티셔닝 작업에서 JobLauncher와 PartitionStep이 동일한 ThreadPoolTaskExecutor를 공유하면서 발생하던 병목 및 TaskRejectedException 문제를 해결했습니다.
- executor 역할 분리 (launcherTaskExecutor, partitionTaskExecutor)
- queue 초과 시 즉시 실패하지 않도록 blocking 정책 적용

이를 통해 대량 파티션 Job에서도 안정적으로 실행되도록 개선했습니다.

<br>


## 🛠 작업 사항

- **`문제 상황`**
- 기존 구조에서는 **JobLauncher와 PartitionStep worker가 동일한 executor를 공유**하고 있었습니다.

### 1. Executor 경쟁으로 인한 실행 병목

* JobLauncher thread → `Future.get()`으로 worker 완료 대기
* Partition worker → 실행 가능한 thread 대기

결과적으로 다음과 같은 구조가 발생할 수 있었습니다.

```
launcher thread → worker 완료 대기
worker task → 실행 가능한 thread 대기
```
-> 이는 실질적인 deadlock에 가까운 상태를 유발할 가능성

<br>

### 2. Queue 초과 시 Job 즉시 실패

- 기존 executor는 `AbortPolicy`를 사용하고 있어 queue가 가득 차면 TaskRejectedException이 즉시 발생해서 모든 잡들이 전부 실패로 떴습니다

예시
```
30일 범위 × 카테고리 6개
→ 최대 180 partitions
```

queue(100)를 초과하면서 일부 파티션이 reject되어 Job 실패로 이어졌습니다

<br><br>

- **`해결방법`**
### 1. Executor 역할 분리
```
launcherTaskExecutor
 └ JobLauncher

partitionTaskExecutor
 └ PartitionStep worker
```

launcher thread가 worker 실행 리소스를 점유하지 않도록 구조를 개선했습니다.

### 2. Blocking 기반 RejectedExecutionHandler 적용

```java
executor.setRejectedExecutionHandler((runnable, pool) -> {
    try {
        pool.getQueue().put(runnable);
    } catch (InterruptedException e) {
        Thread.currentThread().interrupt();
        throw new RejectedExecutionException("파티션 큐 대기 중 인터럽트", e);
    }
});
```
* queue 초과 시
* 즉시 실패하지 않고 queue 공간이 생길 때까지 대기
* 이후 순차적으로 실행

### 3. CallerRunsPolicy 미사용 이유

`CallerRunsPolicy`는 task 제출 thread가 직접 실행하게 됩니다.

PartitionStep에서는

* master thread가 worker 실행 수행
* 병렬 처리 구조 붕괴
* 전체 처리 흐름 저하

가능성이 있어 queue blocking 방식으로 처리했습니다.

<br>

이번 변경으로 다음 문제가 해결됩니다.

* JobLauncher / Partition worker executor 경쟁 제거
* launcher thread로 인한 worker starvation 방지
* queue 초과 시 TaskRejectedException 즉시 실패 방지
* 대량 파티션 Job 안정성 향상


## ✅ 작업 항목

* [x] executor 역할 분리
* [x] blocking RejectedExecutionHandler 적용
* [x] batch async 구조 개선

## 결과
- 1분동안 약 23790건 수집 배치 쿼리 정상적으로 끊기지 않고 작동됨(2024-01-01 ~ 2024-06-30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 배치 작업 실행기 구성이 조정되어 실행자 설정(스레드/대기 큐) 최적화가 이루어졌습니다.
* **New Features**
  * 분할(파티셔닝) 처리용 작업 실행자 구성이 새로 추가되었습니다.
* **Refactor**
  * 기존 배치 잡들이 새로 추가된 분할 실행자를 사용하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->